### PR TITLE
[#114] Add Dockerfiles for building and running HTTP API (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,15 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
         "port": 9000,
 
         // The minimum log level needed before logging activity.
-        "log_level": "warn",
+        //
+        // The following values are supported:
+        // - trace
+        // - debug
+        // - info
+        // - warn
+        // - error
+        // - critical
+        "log_level": "info",
 
         // Defines options that affect various authentication schemes.
         "authentication": {

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+set -x
+
+# Compile the GenQuery2 project.
+mkdir /_build_genquery2
+cd /_build_genquery2
+cmake -GNinja /genquery2_source
+ninja package
+apt-get install -y ./*.deb
+cp ./*.deb /packages_output
+
+# Return to the root directory.
+cd /
+
+# Compile the HTTP API project.
+mkdir /_build_http_api
+cd /_build_http_api
+cmake -GNinja -DIRODS_ENABLE_GENQUERY2=YES /http_api_source
+ninja package
+cp ./*.deb /packages_output

--- a/irods_builder.Dockerfile
+++ b/irods_builder.Dockerfile
@@ -1,0 +1,64 @@
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Re-enable apt caching for RUN --mount
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y --purge && \
+    rm -rf /tmp/*
+# To mark all installed packages as manually installed:
+#apt-mark showauto | xargs -r apt-mark manual
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        git \
+        gnupg \
+        lsb-release \
+        wget \
+    && \
+    rm -rf /tmp/*
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list
+
+ARG irods_version=4.3.1-0~jammy
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        apt-transport-https \
+        flex \
+        bison \
+        g++-11 \
+        gcc-11 \
+        irods-dev=${irods_version} \
+        irods-runtime=${irods_version} \
+        irods-externals-clang13.0.0-0 \
+        irods-externals-cmake3.21.4-0 \
+        irods-externals-fmt8.1.1-0 \
+        irods-externals-json3.10.4-0 \
+        irods-externals-jwt-cpp0.6.99.0-0 \
+        irods-externals-nanodbc2.13.0-1 \
+        irods-externals-spdlog1.9.2-1 \
+        libcurl4-gnutls-dev \
+        libssl-dev \
+        libssl3 \
+        ninja-build \
+    && \
+    rm -rf /tmp/*
+
+ARG cmake_path="/opt/irods-externals/cmake3.21.4-0/bin"
+ENV PATH=${cmake_path}:$PATH
+
+COPY --chmod=755 build_packages.sh /
+ENTRYPOINT ["/build_packages.sh"]

--- a/irods_runner.Dockerfile
+++ b/irods_runner.Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:22.04
+
+SHELL ["/bin/bash", "-c"]
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Re-enable apt caching for RUN --mount
+RUN rm -f /etc/apt/apt.conf.d/docker-clean && \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
+
+# Make sure we're starting with an up-to-date image
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get autoremove -y --purge && \
+    rm -rf /tmp/*
+# To mark all installed packages as manually installed:
+#apt-mark showauto | xargs -r apt-mark manual
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        gnupg \
+        lsb-release \
+        wget \
+    && \
+    rm -rf /tmp/*
+
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list
+
+ARG irods_version=4.3.1-0~jammy
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y \
+        apt-transport-https \
+        g++-11 \
+        gcc \
+        gcc-11 \
+        irods-runtime=${irods_version} \
+        irods-externals-clang-runtime13.0.0-0 \
+    && \
+    rm -rf /tmp/*
+
+COPY ./*.deb /
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update && \
+    apt-get install -y /*.deb && \
+    rm -rf /tmp/*
+
+# Create a dedicated user for running the HTTP API.
+ARG http_api_user=irods_http_api
+RUN adduser --disabled-password ${http_api_user}
+USER ${http_api_user}
+
+# Remove once the environment_properties::capture provides an option for
+# not printing error messages when irods_environment.json does not exist.
+RUN mkdir /home/${http_api_user}/.irods && \
+    echo '{}' > /home/${http_api_user}/.irods/irods_environment.json
+
+ENTRYPOINT ["irods_http_api", "/config.json"]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,7 +180,7 @@ auto print_configuration_template() -> void
         "host": "0.0.0.0",
         "port": 9000,
 
-        "log_level": "warn",
+        "log_level": "info",
 
         "authentication": {{
             "eviction_check_interval_in_seconds": 60,


### PR DESCRIPTION
This includes compiling GenQuery2.

This currently compiles and runs on Ubuntu 22. ~I have to work out some issues with invoking the GenQuery2 parser before this is ready.~

I'm also still settling on the design.

Thoughts and opinions welcome.