### PR TITLE
`process_stash` fix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   ${CMAKE_CURRENT_SOURCE_DIR}/crlf_parser.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/globals.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/process_stash.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/session.cpp)
 
 target_compile_definitions(

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -70,7 +70,7 @@ namespace irods::http
     struct client_identity_resolution_result
     {
         std::optional<response_type> response;
-        const authenticated_client_info* client_info{};
+        authenticated_client_info client_info{};
     }; // struct client_identity_resolution_result
 
     class connection_facade // NOLINT(cppcoreguidelines-special-member-functions)

--- a/src/endpoints/authentication/impl.cpp
+++ b/src/endpoints/authentication/impl.cpp
@@ -3,6 +3,7 @@
 #include "common.hpp"
 #include "globals.hpp"
 #include "log.hpp"
+#include "process_stash.hpp"
 #include "session.hpp"
 #include "version.hpp"
 
@@ -11,7 +12,6 @@
 #include <irods/client_connection.hpp>
 #include <irods/irods_at_scope_exit.hpp>
 #include <irods/irods_exception.hpp>
-#include <irods/process_stash.hpp>
 #include <irods/rcConnect.h>
 #include <irods/user_administration.hpp>
 
@@ -350,7 +350,7 @@ namespace irods::http::handler
 							.at(nlohmann::json::json_pointer{"/http_server/authentication/basic/timeout_in_seconds"})
 							.get<int>();
 
-					auto bearer_token = irods::process_stash::insert(authenticated_client_info{
+					auto bearer_token = irods::http::process_stash::insert(authenticated_client_info{
 						.auth_scheme = authorization_scheme::openid_connect,
 						.username = std::move(irods_name),
 						.expires_at = std::chrono::steady_clock::now() + std::chrono::seconds{seconds}});
@@ -464,7 +464,7 @@ namespace irods::http::handler
 						irods::http::globals::configuration()
 							.at(nlohmann::json::json_pointer{"/http_server/authentication/basic/timeout_in_seconds"})
 							.get<int>();
-					auto bearer_token = irods::process_stash::insert(authenticated_client_info{
+					auto bearer_token = irods::http::process_stash::insert(authenticated_client_info{
 						.auth_scheme = authorization_scheme::basic,
 						.username = std::move(username),
 						.password = std::move(password),
@@ -532,7 +532,7 @@ namespace irods::http::handler
 						irods::http::globals::configuration()
 							.at(nlohmann::json::json_pointer{"/http_server/authentication/basic/timeout_in_seconds"})
 							.get<int>();
-					auto bearer_token = irods::process_stash::insert(authenticated_client_info{
+					auto bearer_token = irods::http::process_stash::insert(authenticated_client_info{
 						.auth_scheme = authorization_scheme::openid_connect,
 						.username = std::move(irods_name),
 						.expires_at = std::chrono::steady_clock::now() + std::chrono::seconds{seconds}});

--- a/src/endpoints/collections/impl.cpp
+++ b/src/endpoints/collections/impl.cpp
@@ -129,10 +129,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -146,7 +146,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 // Enable ticket if the request includes one.
                 if (const auto iter = _args.find("ticket"); iter != std::end(_args)) {
@@ -227,10 +227,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -244,7 +244,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 // Enable ticket if the request includes one.
                 if (const auto iter = _args.find("ticket"); iter != std::end(_args)) {
@@ -327,10 +327,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -344,7 +344,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 fs::client::create_collections(conn, lpath_iter->second);
 
                 res.body() = json{
@@ -388,10 +388,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -405,7 +405,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (!fs::client::is_collection(conn, lpath_iter->second)) {
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request, json{
@@ -471,10 +471,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -488,7 +488,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (!fs::client::is_collection(conn, old_lpath_iter->second)) {
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request, json{
@@ -558,10 +558,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -575,7 +575,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (!fs::client::is_collection(conn, lpath_iter->second)) {
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request, json{

--- a/src/endpoints/data_objects/impl.cpp
+++ b/src/endpoints/data_objects/impl.cpp
@@ -301,10 +301,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -318,7 +318,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 // Enable ticket if the request includes one.
                 if (const auto iter = _args.find("ticket"); iter != std::end(_args)) {
@@ -425,10 +425,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -518,7 +518,7 @@ namespace
                     log::trace("{}: Opening data object [{}] for write.", fn, lpath_iter->second);
                     log::trace("{}: (write) Initializing for single buffer write.", fn);
 
-                    conn = irods::get_connection(client_info->username);
+                    conn = irods::get_connection(client_info.username);
 
                     // Enable ticket if the request includes one.
                     if (const auto iter = _args.find("ticket"); iter != std::end(_args)) {
@@ -647,10 +647,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -702,7 +702,7 @@ namespace
                     }
 
                     // Open the first stream.
-                    pw_streams.emplace_back(std::make_shared<parallel_write_stream>(client_info->username, lpath_iter->second, openmode, ticket));
+                    pw_streams.emplace_back(std::make_shared<parallel_write_stream>(client_info.username, lpath_iter->second, openmode, ticket));
 
                     auto& first_stream = pw_streams.front()->stream();
                     log::debug("{}: replica token=[{}], replica number=[{}], leaf resource name=[{}]",
@@ -713,7 +713,7 @@ namespace
 
                     // Open secondary streams using the first stream as a base.
                     for (int i = 0; i < stream_count; ++i) {
-                        pw_streams.emplace_back(std::make_shared<parallel_write_stream>(client_info->username,
+                        pw_streams.emplace_back(std::make_shared<parallel_write_stream>(client_info.username,
                                                                                         lpath_iter->second,
                                                                                         openmode,
                                                                                         ticket,
@@ -793,10 +793,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -885,10 +885,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -923,7 +923,7 @@ namespace
                     addKeyVal(&input.condInput, ADMIN_KW, "");
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rcDataObjRepl(static_cast<RcComm*>(conn), &input);
 
                 res.body() = json{
@@ -958,10 +958,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1001,7 +1001,7 @@ namespace
 
                 addKeyVal(&input.condInput, COPIES_KW, "1");
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rcDataObjTrim(static_cast<RcComm*>(conn), &input);
 
                 res.body() = json{
@@ -1036,10 +1036,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1053,7 +1053,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (!fs::client::is_data_object(conn, lpath_iter->second)) {
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request, json{
@@ -1136,10 +1136,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1153,7 +1153,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 // Enable ticket if the request includes one.
                 if (const auto iter = _args.find("ticket"); iter != std::end(_args)) {
@@ -1237,10 +1237,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1286,7 +1286,7 @@ namespace
                     addKeyVal(&input.condInput, FORCE_FLAG_KW, "");
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (const auto ec = rcPhyPathReg(static_cast<RcComm*>(conn), &input); ec < 0) {
                     res.result(http::status::bad_request);
@@ -1331,10 +1331,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1348,7 +1348,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (!fs::client::is_data_object(conn, lpath_iter->second)) {
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request, json{
@@ -1412,10 +1412,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1429,7 +1429,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (!fs::client::is_data_object(conn, old_lpath_iter->second)) {
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request, json{
@@ -1488,10 +1488,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1528,7 +1528,7 @@ namespace
                     }
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto copied = fs::client::copy_data_object(conn, src_lpath_iter->second, dst_lpath_iter->second, opts);
 
                 res.body() = json{
@@ -1573,10 +1573,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1634,7 +1634,7 @@ namespace
                     {"options", options}
                 };
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rc_touch(static_cast<RcComm*>(conn), input.dump().c_str());
 
                 res.body() = json{
@@ -1669,10 +1669,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1714,7 +1714,7 @@ namespace
                 char* checksum{};
                 irods::at_scope_exit free_checksum{[&checksum] { std::free(checksum); }};
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rcDataObjChksum(static_cast<RcComm*>(conn), &input, &checksum);
 
                 res.body() = json{
@@ -1750,10 +1750,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -1793,7 +1793,7 @@ namespace
                 char* results{};
                 irods::at_scope_exit free_results{[&results] { std::free(results); }};
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rcDataObjChksum(static_cast<RcComm*>(conn), &input, &results);
 
                 json response{

--- a/src/endpoints/query/impl.cpp
+++ b/src/endpoints/query/impl.cpp
@@ -130,8 +130,8 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
-        log::info("{}: client_info->username = [{}]", __func__, client_info->username);
+        const auto client_info = result.client_info;
+        log::info("{}: client_info.username = [{}]", __func__, client_info.username);
 
         irods::http::globals::background_task([fn = __func__, _sess_ptr, req = std::move(_req), args = std::move(_args), client_info]() mutable {
             auto query_iter = args.find("query");
@@ -160,7 +160,7 @@ namespace
                 json::array_t row;
                 json::array_t rows;
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if ("genquery2" == parser) {
 #ifdef IRODS_ENABLE_GENQUERY2
@@ -298,8 +298,8 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
-        log::info("{}: client_info->username = [{}]", __func__, client_info->username);
+        const auto client_info = result.client_info;
+        log::info("{}: client_info.username = [{}]", __func__, client_info.username);
 
         const auto name_iter = _args.find("name");
         if (name_iter == std::end(_args)) {
@@ -367,7 +367,7 @@ namespace
                     int offset_counter = 0;
                     int count_counter = 0;
 
-                    auto conn = irods::get_connection(client_info->username);
+                    auto conn = irods::get_connection(client_info.username);
 
                     for (auto&& r : qb.build<RcComm>(conn, name)) {
                         if (offset_counter < offset) {

--- a/src/endpoints/resources/impl.cpp
+++ b/src/endpoints/resources/impl.cpp
@@ -128,10 +128,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -170,7 +170,7 @@ namespace
                     resc_info.context_string = ctx_iter->second;
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::add_resource(conn, resc_info);
 
                 res.body() = json{
@@ -205,10 +205,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -222,7 +222,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::remove_resource(conn, name_iter->second);
 
                 res.body() = json{
@@ -258,10 +258,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -302,10 +302,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -325,7 +325,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 const auto ctx_iter = _args.find("context");
                 if (ctx_iter != std::end(_args)) {
@@ -367,10 +367,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -390,7 +390,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::remove_child_resource(conn, parent_name_iter->second, child_name_iter->second);
 
                 res.body() = json{
@@ -425,10 +425,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -442,7 +442,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::rebalance_resource(conn, name_iter->second);
 
                 res.body() = json{
@@ -477,10 +477,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -494,7 +494,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 json::object_t info;
                 bool exists = false;

--- a/src/endpoints/rules/impl.cpp
+++ b/src/endpoints/rules/impl.cpp
@@ -126,10 +126,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -176,7 +176,7 @@ namespace
                 json stdout_output;
                 json stderr_output;
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rcExecMyRule(static_cast<RcComm*>(conn), &input, &out_param_array);
 
                 if (ec >= 0) {
@@ -242,10 +242,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -262,7 +262,7 @@ namespace
                 RuleExecDeleteInput input{};
                 std::strncpy(input.ruleExecId, rule_id_iter->second.c_str(), sizeof(RuleExecDeleteInput::ruleExecId));
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rcRuleExecDel(static_cast<RcComm*>(conn), &input);
 
                 res.body() = json{
@@ -297,10 +297,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -331,7 +331,7 @@ namespace
                     std::free(out_param_array);
                 }};
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rcExecMyRule(static_cast<RcComm*>(conn), &input, &out_param_array);
 
                 std::vector<std::string> plugin_instances;

--- a/src/endpoints/shared_api_operations.cpp
+++ b/src/endpoints/shared_api_operations.cpp
@@ -40,10 +40,10 @@ namespace irods::http::shared_api_operations
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _entity_type, _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             ::http::response<::http::string_body> res{::http::status::ok, _req.version()};
             res.set(::http::field::server, irods::http::version::server_name);
@@ -63,7 +63,7 @@ namespace irods::http::shared_api_operations
                     return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 // Verify the logical path points to the entity type we expect.
                 switch (_entity_type) {
@@ -147,10 +147,10 @@ namespace irods::http::shared_api_operations
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _entity_type, _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             ::http::response<::http::string_body> res{::http::status::ok, _req.version()};
             res.set(::http::field::server, irods::http::version::server_name);
@@ -213,7 +213,7 @@ namespace irods::http::shared_api_operations
                 // NOLINTNEXTLINE(cppcoreguidelines-owning-memory, cppcoreguidelines-no-malloc)
                 irods::at_scope_exit_unsafe free_output{[&output] { std::free(output); }};
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ec = rc_atomic_apply_metadata_operations(static_cast<RcComm*>(conn), json_input.c_str(), &output);
 
                 if (ec != 0) {

--- a/src/endpoints/tickets/impl.cpp
+++ b/src/endpoints/tickets/impl.cpp
@@ -120,10 +120,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -165,10 +165,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -209,10 +209,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -238,7 +238,7 @@ namespace
                     }
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto ticket = adm::ticket::client::create_ticket(conn, ticket_type, lpath_iter->second);
 
                 auto constraint_iter = _args.find("use-count");
@@ -334,10 +334,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -351,7 +351,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::ticket::client::delete_ticket(conn, name_iter->second);
 
                 res.body() = json{

--- a/src/endpoints/users_groups/impl.cpp
+++ b/src/endpoints/users_groups/impl.cpp
@@ -147,10 +147,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -192,7 +192,7 @@ namespace
                     zone_type = adm::zone_type::remote;
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::add_user(conn, adm::user{name_iter->second, zone_iter->second}, user_type, zone_type);
 
                 res.body() = json{
@@ -227,10 +227,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -250,7 +250,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::remove_user(conn, adm::user{name_iter->second, zone_iter->second});
 
                 res.body() = json{
@@ -285,10 +285,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -317,7 +317,7 @@ namespace
                 static const auto& proxy_user_password = irods::http::globals::configuration().at(json::json_pointer{"/irods_client/proxy_admin_account/password"}).get_ref<const std::string&>();
                 const adm::user_password_property prop{new_password_iter->second, proxy_user_password};
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::modify_user(conn, adm::user{name_iter->second, zone_iter->second}, prop);
 
                 res.body() = json{
@@ -352,10 +352,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -383,7 +383,7 @@ namespace
 
                 const adm::user_type_property prop{adm::to_user_type(new_user_type_iter->second)};
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::modify_user(conn, adm::user{name_iter->second, zone_iter->second}, prop);
 
                 res.body() = json{
@@ -419,10 +419,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -464,10 +464,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -508,10 +508,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -525,7 +525,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::add_group(conn, adm::group{name_iter->second});
 
                 res.body() = json{
@@ -560,10 +560,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -577,7 +577,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::remove_group(conn, adm::group{name_iter->second});
 
                 res.body() = json{
@@ -612,10 +612,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -641,7 +641,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::add_user_to_group(conn, adm::group{group_iter->second}, adm::user{user_iter->second, zone_iter->second});
 
                 res.body() = json{
@@ -676,10 +676,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -705,7 +705,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 adm::client::remove_user_from_group(conn, adm::group{group_iter->second}, adm::user{user_iter->second, zone_iter->second});
 
                 res.body() = json{
@@ -740,10 +740,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -751,7 +751,7 @@ namespace
             res.keep_alive(_req.keep_alive());
 
             try {
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 const auto users = adm::client::users(conn);
 
                 std::vector<json> v;
@@ -797,10 +797,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -808,7 +808,7 @@ namespace
             res.keep_alive(_req.keep_alive());
 
             try {
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
                 auto groups = adm::client::groups(conn);
 
                 std::vector<std::string> v;
@@ -852,10 +852,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -896,10 +896,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -925,7 +925,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 const adm::group group{adm::group{group_iter->second}};
                 const adm::user user{adm::user{user_iter->second, zone_iter->second}};
@@ -963,10 +963,10 @@ namespace
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -980,7 +980,7 @@ namespace
                     return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
                 }
 
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 json info{
                     {"irods_response", {

--- a/src/endpoints/zones/impl.cpp
+++ b/src/endpoints/zones/impl.cpp
@@ -33,10 +33,10 @@ namespace irods::http::handler
             return _sess_ptr->send(std::move(*result.response));
         }
 
-        const auto* client_info = result.client_info;
+        const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req)] {
-            log::info("{}: client_info->username = [{}]", fn, client_info->username);
+            log::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             const auto url = irods::http::parse_url(_req);
 
@@ -55,7 +55,7 @@ namespace irods::http::handler
             irods::at_scope_exit free_bbuf{[&bbuf] { freeBBuf(bbuf); }};
 
             {
-                auto conn = irods::get_connection(client_info->username);
+                auto conn = irods::get_connection(client_info.username);
 
                 if (const auto ec = rcZoneReport(static_cast<RcComm*>(conn), &bbuf); ec != 0) {
                     log::error("{}: rcZoneReport error: [{}]", fn, ec);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,12 +3,12 @@
 #include "handlers.hpp"
 #include "log.hpp"
 #include "session.hpp"
+#include "process_stash.hpp"
 #include "version.hpp"
 
 #include <irods/connection_pool.hpp>
 #include <irods/fully_qualified_username.hpp>
 #include <irods/irods_configuration_keywords.hpp>
-#include <irods/process_stash.hpp>
 #include <irods/rcConnect.h>
 #include <irods/rcMisc.h>
 #include <irods/rodsClient.h>
@@ -431,7 +431,7 @@ class bearer_token_eviction_manager
             }
 
             log::trace("Evicting expired bearer tokens ...");
-            irods::process_stash::erase_if([](const auto& _k, const auto& _v) {
+            irods::http::process_stash::erase_if([](const auto& _k, const auto& _v) {
                 try {
                     const auto* p = boost::any_cast<const irods::http::authenticated_client_info>(&_v);
                     const auto erase_token = (p && std::chrono::steady_clock::now() >= p->expires_at);

--- a/src/process_stash.cpp
+++ b/src/process_stash.cpp
@@ -1,0 +1,84 @@
+#include "process_stash.hpp"
+
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+
+#include <iterator>
+#include <optional>
+#include <shared_mutex>
+#include <unordered_map>
+
+namespace
+{
+    // A mapping containing handles to heterogenous objects.
+    std::unordered_map<std::string, boost::any> g_stash; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+
+    // A mutex which protects the map from data corruption.
+    std::shared_mutex g_mtx; // NOLINT(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp)
+
+    auto generate_unique_key() -> std::string
+    {
+        std::string uuid;
+        constexpr auto uuid_length{36};
+        uuid.reserve(uuid_length);
+        uuid = to_string(boost::uuids::random_generator{}());
+
+        while (g_stash.find(uuid) != std::end(g_stash)) {
+            uuid = to_string(boost::uuids::random_generator{}());
+        }
+
+        return uuid;
+    } // generate_unique_key
+} // anonymous namespace
+
+namespace irods::http::process_stash
+{
+    auto insert(boost::any _value) -> std::string
+    {
+        std::lock_guard lock{g_mtx};
+        return g_stash.insert_or_assign(generate_unique_key(), std::move(_value)).first->first;
+    } // insert
+
+    auto find(const std::string& _key) -> std::optional<boost::any>
+    {
+        {
+            std::shared_lock lock{g_mtx};
+            if (auto iter = g_stash.find(_key); iter != std::end(g_stash)) {
+                return iter->second;
+            }
+        }
+
+        return std::nullopt;
+    } // find
+
+    auto erase(const std::string& _key) -> bool
+    {
+        std::lock_guard lock{g_mtx};
+        return g_stash.erase(_key);
+    } // erase
+
+    auto erase_if(const std::function<bool(const std::string&, const boost::any&)>& _pred) -> std::size_t
+    {
+        std::lock_guard lock{g_mtx};
+        return std::erase_if(g_stash, [&_pred](const auto& _item) {
+            const auto& [k, v] = _item;
+            return _pred(k, v);
+        });
+    } // erase_if
+
+    auto handles() -> std::vector<std::string>
+    {
+        std::vector<std::string> handles;
+
+        {
+            std::shared_lock lock{g_mtx};
+            handles.reserve(g_stash.size());
+            for (const auto& [k, v] : g_stash) {
+                handles.push_back(k);
+            }
+        }
+
+        return handles;
+    } // handles
+} // namespace irods::http::process_stash

--- a/src/process_stash.hpp
+++ b/src/process_stash.hpp
@@ -1,0 +1,89 @@
+#ifndef IRODS_HTTP_PROCESS_STASH_HPP
+#define IRODS_HTTP_PROCESS_STASH_HPP
+
+/// \file
+
+// Boost.Any is used instead of the implementation provided by the standard library
+// because it produces the correct results when used across shared library boundaries.
+#include <boost/any.hpp>
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <vector>
+
+/// Defines the set of free functions used to manage the process stash.
+///
+/// In iRODS, a process stash is a key-value store which allows a process to store arbitrary
+/// data in local memory. Insertions of data generate unique handles which allow retrieval of
+/// the data. No two processes share the same data (unless one is a child process).
+///
+/// \since 4.2.12
+namespace irods::http::process_stash
+{
+    /// Inserts an object into the process stash.
+    ///
+    /// This function is thread-safe.
+    ///
+    /// \param[in] _value The object to insert.
+    ///
+    /// \returns A string representing the handle to the inserted object.
+    ///
+    /// \since 4.2.12
+    auto insert(boost::any _value) -> std::string;
+
+    /// Searches the process stash for the value associated with a specific key.
+    ///
+    /// This function is thread-safe.
+    ///
+    /// \param[in] _key The string which maps to the value of interest.
+    ///
+    /// \returns A std::optional<boost::any> containing the value of interest.
+    /// \retval A non-empty std::optional<boost::any> object if the key exists.
+    /// \retval An empty std::optional<boost::any> object otherwise.
+    ///
+    /// \since 4.2.12
+    auto find(const std::string& _key) -> std::optional<boost::any>;
+
+    /// Removes a value from the process stash.
+    ///
+    /// This function is thread-safe.
+    ///
+    /// \param[in] _key The string which maps to the value of interest.
+    ///
+    /// \returns A boolean indicating if an element is removed.
+    ///
+    /// \since 4.2.12
+    auto erase(const std::string& _key) -> bool;
+
+    /// Removes all entries satisfying the predicate.
+    ///
+    /// This function is thread-safe.
+    ///
+    /// \param[in] _pred \parblock The predicate to test each entry against.
+    ///
+    /// \p _pred must take a std::string and boost::any by reference and return a boolean
+    /// indicating whether the entry should be removed. The arguments passed must be
+    /// treated as read-only.
+    ///
+    /// The std::string parameter is the handle mapped to the object stored in the boost::any.
+    ///
+    /// The boost::any parameter is the wrapped object identified by the handle.
+    ///
+    /// If \p _pred returns \p true, the entry is removed.
+    /// \endparblock
+    ///
+    /// \returns The number of elements removed.
+    ///
+    /// \since 4.3.1
+    auto erase_if(const std::function<bool(const std::string&, const boost::any&)>& _pred) -> std::size_t;
+
+    /// Returns all handles in the process stash.
+    ///
+    /// This function is thread-safe.
+    ///
+    /// \since 4.2.12
+    auto handles() -> std::vector<std::string>;
+} // namespace irods::http::process_stash
+
+#endif // IRODS_HTTP_PROCESS_STASH_HPP


### PR DESCRIPTION
This should fix the potential `process_stash` issues stated in irods/irods#7297.
This solution just returns a copy of the object desired, rather than providing a pointer.

All existing tests pass with the changes.