### PR TITLE
More 0.1.0 changes

### DIFF
--- a/API.md
+++ b/API.md
@@ -724,24 +724,28 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
 
 Writes bytes to a data object.
 
-To write to a data object in parallel, see [parallel-write-init](#parallel-write-init).
-
 #### Request
 
 ```bash
 curl http://localhost:<port>/irods-http-api/<version>/data-objects \
     -H 'Authorization: Bearer <token>' \
-    --data-urlencode 'op=write' \
-    --data-urlencode 'lpath=<string>' \ # Absolute logical path to a data object.
-    --data-urlencode 'resource=<string>' \ # The root resource to write to. Optional.
-    --data-urlencode 'offset=<integer>' \ # Number of bytes to skip. Defaults to 0.
-    --data-urlencode 'count=<integer>' \ # Number of bytes to write.
-    --data-urlencode 'truncate=<integer>' \ # 0 or 1. Defaults to 1. Truncates the data object before writing.
-    --data-urlencode 'append=<integer>' \ # 0 or 1. Defaults to 0. Appends the bytes to the data object.
-    --data-urlencode 'bytes=<binary_data>' \ # The bytes to write.
-    --data-urlencode 'parallel-write-handle=<string>' \ # The handle to use when writing in parallel.
-    --data-urlencode 'stream-index=<integer>' # The stream to use when writing in parallel.
+    [-F,--data-urlencode] 'op=write' \
+    [-F,--data-urlencode] 'lpath=<string>' \ # Absolute logical path to a data object.
+    [-F,--data-urlencode] 'resource=<string>' \ # The root resource to write to. Optional.
+    [-F,--data-urlencode] 'offset=<integer>' \ # Number of bytes to skip. Defaults to 0.
+    [-F,--data-urlencode] 'count=<integer>' \ # Number of bytes to write.
+    [-F,--data-urlencode] 'truncate=<integer>' \ # 0 or 1. Defaults to 1. Truncates the data object before writing.
+    [-F,--data-urlencode] 'append=<integer>' \ # 0 or 1. Defaults to 0. Appends the bytes to the data object.
+    [-F,--data-urlencode] 'bytes=<binary_data>;type=application/octet-stream' \ # The bytes to write.
+    [-F,--data-urlencode] 'parallel-write-handle=<string>' \ # The handle to use when writing in parallel. Optional.
+    [-F,--data-urlencode] 'stream-index=<integer>' # The stream to use when writing in parallel. Optional.
 ```
+
+This is the full set of parameters supported by the operation.
+
+When sending large amounts of data or writing in parallel, prefer multipart/form-data over application/x-www-form-urlencoded as the Content-Type.
+
+`parallel-write-handle` and `stream-index` only apply when writing to a replica in parallel. To obtain a parallel-write-handle, see [parallel-write-init](#parallel-write-init).
 
 #### Response
 

--- a/API.md
+++ b/API.md
@@ -43,8 +43,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -75,8 +75,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -107,8 +107,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "type": "string",
     "inheritance_enabled": false,
@@ -150,8 +150,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "entries": [
         "string",
@@ -186,8 +186,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -229,8 +229,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -240,15 +240,15 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string", // Optional
+        "status_code": 0
+        "status_message": "string", // Optional
         "failed_operation": {
             "operation": {
                 "entity_name": "string", // The name of a user or group.
                 "acl": "string" // null, read, write, or own.
             },
             "operation_index": 0,
-            "error_message": "string"
+            "status_message": "string"
         }
     }
 }
@@ -291,8 +291,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -302,8 +302,8 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string", // Optional
+        "status_code": 0
+        "status_message": "string", // Optional
         "failed_operation": {
             "operation": {
                 "operation": "string", // add or remove.
@@ -312,7 +312,7 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
                 "units": "string" // Optional.
             },
             "operation_index": 0,
-            "error_message": "string"
+            "status_message": "string"
         }
     }
 }
@@ -339,8 +339,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -374,8 +374,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -406,8 +406,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -441,8 +441,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "checksum": "string"
 }
@@ -474,8 +474,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "results": {
         // Verification results. This object only exists if the operation found inconsistencies
@@ -516,8 +516,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "type": "string",
     "permissions": [
@@ -558,8 +558,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -590,8 +590,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "copied": false
 }
@@ -622,8 +622,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -656,8 +656,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -689,8 +689,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -750,8 +750,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```
 {
     "irods_response": {
-        "error_code": 0,
-        "error_message": "string" // Optional
+        "status_code": 0,
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -782,8 +782,8 @@ curl http://localhost:<port>/irods-http-api/<version>/data-objects \
 ```
 {
     "irods_response": {
-        "error_code": 0,
-        "error_message": "string" // Optional
+        "status_code": 0,
+        "status_message": "string" // Optional
     },
     "parallel_write_handle": "string"
 }
@@ -809,8 +809,8 @@ curl http://localhost:<port>/irods-http-api/<version>/data-objects \
 ```
 {
     "irods_response": {
-        "error_code": 0,
-        "error_message": "string" // Optional
+        "status_code": 0,
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -852,8 +852,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -863,8 +863,8 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string", // Optional
+        "status_code": 0
+        "status_message": "string", // Optional
         "failed_operation": {
             "operation": {
                 "operation": "string", // add or remove.
@@ -873,7 +873,7 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
                 "units": "string" // Optional.
             },
             "operation_index": 0,
-            "error_message": "string"
+            "status_message": "string"
         }
     }
 }
@@ -902,8 +902,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -945,8 +945,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -956,15 +956,15 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string", // Optional
+        "status_code": 0
+        "status_message": "string", // Optional
         "failed_operation": {
             "operation": {
                 "entity_name": "string", // The name of a user or group.
                 "acl": "string" // null, read, write, or own.
             },
             "operation_index": 0,
-            "error_message": "string"
+            "status_message": "string"
         }
     }
 }
@@ -1012,8 +1012,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1074,8 +1074,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "rows": [
         ["string", "string", "string"],
@@ -1113,8 +1113,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "rows": [
         ["string", "string", "string"],
@@ -1150,8 +1150,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1178,8 +1178,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1208,8 +1208,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1237,8 +1237,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1265,8 +1265,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1294,8 +1294,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "exists": false,
     "info": {
@@ -1357,8 +1357,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1368,8 +1368,8 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string", // Optional
+        "status_code": 0
+        "status_message": "string", // Optional
         "failed_operation": {
             "operation": {
                 "operation": "string", // add or remove.
@@ -1378,7 +1378,7 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
                 "units": "string" // Optional.
             },
             "operation_index": 0,
-            "error_message": "string"
+            "status_message": "string"
         }
     }
 }
@@ -1406,8 +1406,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "rule_engine_plugin_instances": [
         "string",
@@ -1442,8 +1442,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "stdout": "string",
     "stderr": "string"
@@ -1472,8 +1472,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1510,8 +1510,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "ticket": "string" // The generated ticket string.
 }
@@ -1539,8 +1539,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1571,8 +1571,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1600,8 +1600,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1630,8 +1630,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1660,8 +1660,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1688,8 +1688,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1716,8 +1716,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1746,8 +1746,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1776,8 +1776,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1804,8 +1804,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "users": [
         {
@@ -1840,8 +1840,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "groups": [
         "string",
@@ -1876,8 +1876,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "is_member": false
 }
@@ -1907,8 +1907,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "exists": false,
     "id": "string",
@@ -1955,8 +1955,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     }
 }
 ```
@@ -1966,8 +1966,8 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string", // Optional
+        "status_code": 0
+        "status_message": "string", // Optional
         "failed_operation": {
             "operation": {
                 "operation": "string", // add or remove.
@@ -1976,7 +1976,7 @@ If there was an error, expect either an HTTP status code in the 4XX or 5XX range
                 "units": "string" // Optional.
             },
             "operation_index": 0,
-            "error_message": "string"
+            "status_message": "string"
         }
     }
 }
@@ -2004,8 +2004,8 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 ```js
 {
     "irods_response": {
-        "error_code": 0
-        "error_message": "string" // Optional
+        "status_code": 0
+        "status_message": "string" // Optional
     },
     "zone_report": {
         // Equivalent output of executing izonereport.

--- a/README.md
+++ b/README.md
@@ -299,11 +299,12 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
         // single parallel write handle.
         "max_number_of_parallel_write_streams": 3,
 
-        // The buffer size used for read operations.
-        "max_rbuffer_size_in_bytes": 8192,
+        // The maximum number of bytes that can be read from a data object
+		// during a single read operation.
+        "max_number_of_bytes_per_read_operation": 8192,
 
         // The buffer size used for write operations.
-        "max_wbuffer_size_in_bytes": 8192,
+        "buffer_size_in_bytes_for_write_operations": 8192,
 
         // The number of rows that can be returned by a General or Specific
         // query. If the client specifies a number greater than the value

--- a/src/endpoints/collections/impl.cpp
+++ b/src/endpoints/collections/impl.cpp
@@ -162,7 +162,7 @@ namespace
 							res.result(http::status::internal_server_error);
 							res.body() =
 								json{{"irods_response",
-						              {{"error_code", ec}, {"error_message", "Error enabling ticket on connection."}}}}
+						              {{"status_code", ec}, {"status_message", "Error enabling ticket on connection."}}}}
 									.dump();
 							res.prepare_payload();
 							return _sess_ptr->send(std::move(res));
@@ -173,7 +173,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_COLLECTION}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_COLLECTION}}}}.dump()));
 					}
 
 					json entries;
@@ -193,7 +193,7 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }},
 						{"entries",
 				         entries}}.dump();
@@ -201,13 +201,13 @@ namespace
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -253,7 +253,7 @@ namespace
 							res.result(http::status::internal_server_error);
 							res.body() =
 								json{{"irods_response",
-						              {{"error_code", ec}, {"error_message", "Error enabling ticket on connection."}}}}
+						              {{"status_code", ec}, {"status_message", "Error enabling ticket on connection."}}}}
 									.dump();
 							res.prepare_payload();
 							return _sess_ptr->send(std::move(res));
@@ -266,7 +266,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_COLLECTION}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_COLLECTION}}}}.dump()));
 					}
 
 					json perms;
@@ -283,7 +283,7 @@ namespace
 						json{
 							{"irods_response",
 				             {
-								 {"error_code", 0},
+								 {"status_code", 0},
 							 }},
 							{"type", irods::to_object_type_string(status.type())},
 							{"inheritance_enabled", status.is_inheritance_enabled()},
@@ -296,13 +296,13 @@ namespace
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -343,18 +343,18 @@ namespace
 					auto conn = irods::get_connection(client_info.username);
 					fs::client::create_collections(conn, lpath_iter->second);
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -398,7 +398,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_COLLECTION}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_COLLECTION}}}}.dump()));
 					}
 
 					fs::remove_options opts = fs::remove_options::none;
@@ -416,18 +416,18 @@ namespace
 						fs::client::remove(conn, lpath_iter->second, opts);
 					}
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -471,7 +471,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_COLLECTION}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_COLLECTION}}}}.dump()));
 					}
 
 					const auto new_lpath_iter = _args.find("new-lpath");
@@ -486,26 +486,26 @@ namespace
 						res.body() = json{
 							{"irods_response",
 					         {
-								 {"error_code", 0},
+								 {"status_code", 0},
 							 }}}.dump();
 					}
 					catch (const fs::filesystem_error& e) {
 						res.result(http::status::bad_request);
 						res.body() =
-							json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+							json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 								.dump();
 					}
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -549,7 +549,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_COLLECTION}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_COLLECTION}}}}.dump()));
 					}
 
 					const auto entity_name_iter = _args.find("entity-name");
@@ -583,25 +583,25 @@ namespace
 						res.body() = json{
 							{"irods_response",
 					         {
-								 {"error_code", 0},
+								 {"status_code", 0},
 							 }}}.dump();
 					}
 					catch (const fs::filesystem_error& e) {
 						res.body() =
-							json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+							json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 								.dump();
 					}
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {

--- a/src/endpoints/collections/impl.cpp
+++ b/src/endpoints/collections/impl.cpp
@@ -199,18 +199,21 @@ namespace
 				         entries}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -294,18 +297,21 @@ namespace
 							.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -346,18 +352,21 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -419,18 +428,21 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -490,6 +502,7 @@ namespace
 							 }}}.dump();
 					}
 					catch (const fs::filesystem_error& e) {
+						log::error("{}: {}", fn, e.what());
 						res.result(http::status::bad_request);
 						res.body() =
 							json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
@@ -497,18 +510,21 @@ namespace
 					}
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -587,24 +603,28 @@ namespace
 							 }}}.dump();
 					}
 					catch (const fs::filesystem_error& e) {
+						log::error("{}: {}", fn, e.what());
 						res.body() =
 							json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 								.dump();
 					}
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/src/endpoints/data_objects/impl.cpp
+++ b/src/endpoints/data_objects/impl.cpp
@@ -343,7 +343,7 @@ namespace
 							res.result(http::status::internal_server_error);
 							res.body() =
 								json{{"irods_response",
-						              {{"error_code", ec}, {"error_message", "Error enabling ticket on connection."}}}}
+						              {{"status_code", ec}, {"status_message", "Error enabling ticket on connection."}}}}
 									.dump();
 							res.prepare_payload();
 							return _sess_ptr->send(std::move(res));
@@ -419,13 +419,13 @@ namespace
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -555,7 +555,7 @@ namespace
 							res.result(http::status::internal_server_error);
 							res.body() =
 								json{{"irods_response",
-							          {{"error_code", ec}, {"error_message", "Error enabling ticket on connection."}}}}
+							          {{"status_code", ec}, {"status_message", "Error enabling ticket on connection."}}}}
 									.dump();
 							res.prepare_payload();
 							return _sess_ptr->send(std::move(res));
@@ -638,17 +638,17 @@ namespace
 					out_ptr->close();
 				}
 
-				res.body() = json{{"irods_response", {{"error_code", 0}}}}.dump();
+				res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}.dump();
+					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
@@ -786,7 +786,7 @@ namespace
 					json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }},
 						{"parallel_write_handle", transfer_handle}}
 						.dump();
@@ -794,12 +794,12 @@ namespace
 			catch (const fs::filesystem_error& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}.dump();
+					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
@@ -874,19 +874,19 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -952,7 +952,7 @@ namespace
 						json{
 							{"irods_response",
 				             {
-								 {"error_code", ec},
+								 {"status_code", ec},
 							 }},
 						}
 							.dump();
@@ -960,7 +960,7 @@ namespace
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1027,12 +1027,12 @@ namespace
 					auto conn = irods::get_connection(client_info.username);
 					const auto ec = rcDataObjTrim(static_cast<RcComm*>(conn), &input);
 
-					res.body() = json{{"irods_response", {{"error_code", ec < 0 ? ec : 0}}}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", ec < 0 ? ec : 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1079,7 +1079,7 @@ namespace
 					return _sess_ptr->send(irods::http::fail(
 						res,
 						http::status::bad_request,
-						json{{"irods_response", {{"error_code", NOT_A_DATA_OBJECT}}}}.dump()));
+						json{{"irods_response", {{"status_code", NOT_A_DATA_OBJECT}}}}.dump()));
 				}
 
 				const auto entity_name_iter = _args.find("entity-name");
@@ -1111,18 +1111,18 @@ namespace
 				res.body() = json{
 					{"irods_response",
 				     {
-						 {"error_code", 0},
+						 {"status_code", 0},
 					 }}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}.dump();
+					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
@@ -1174,7 +1174,7 @@ namespace
 							res.result(http::status::internal_server_error);
 							res.body() =
 								json{{"irods_response",
-						              {{"error_code", ec}, {"error_message", "Error enabling ticket on connection."}}}}
+						              {{"status_code", ec}, {"status_message", "Error enabling ticket on connection."}}}}
 									.dump();
 							res.prepare_payload();
 							return _sess_ptr->send(std::move(res));
@@ -1187,7 +1187,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_DATA_OBJECT}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_DATA_OBJECT}}}}.dump()));
 					}
 
 					json perms;
@@ -1204,7 +1204,7 @@ namespace
 						json{
 							{"irods_response",
 				             {
-								 {"error_code", 0},
+								 {"status_code", 0},
 							 }},
 							{"type", irods::to_object_type_string(status.type())},
 							{"permissions", perms},
@@ -1218,13 +1218,13 @@ namespace
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1300,17 +1300,17 @@ namespace
 
 					if (const auto ec = rcPhyPathReg(static_cast<RcComm*>(conn), &input); ec < 0) {
 						res.result(http::status::bad_request);
-						res.body() = json{{"irods_response", {{"error_code", ec}}}}.dump();
+						res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 						res.prepare_payload();
 						_sess_ptr->send(std::move(res));
 					}
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1354,7 +1354,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_DATA_OBJECT}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_DATA_OBJECT}}}}.dump()));
 					}
 
 					fs::extended_remove_options opts{};
@@ -1370,18 +1370,18 @@ namespace
 					// There's no admin flag for removal.
 					fs::client::remove(conn, lpath_iter->second, opts);
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1425,7 +1425,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_DATA_OBJECT}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_DATA_OBJECT}}}}.dump()));
 					}
 
 					const auto new_lpath_iter = _args.find("new-lpath");
@@ -1439,19 +1439,19 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code().value()}, {"error_message", e.what()}}}}
+						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1516,21 +1516,21 @@ namespace
 					const auto copied =
 						fs::client::copy_data_object(conn, src_lpath_iter->second, dst_lpath_iter->second, opts);
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}, {"copied", copied}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"copied", copied}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response",
-				              {{"error_code",
+				              {{"status_code",
 				                e.code().value() == INVALID_OBJECT_TYPE ? NOT_A_DATA_OBJECT : e.code().value()},
-				               {"error_message", e.what()}}}}
+				               {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1621,17 +1621,17 @@ namespace
 						return _sess_ptr->send(irods::http::fail(
 							res,
 							http::status::bad_request,
-							json{{"irods_response", {{"error_code", NOT_A_DATA_OBJECT}}}}.dump()));
+							json{{"irods_response", {{"status_code", NOT_A_DATA_OBJECT}}}}.dump()));
 					}
 
 					const auto ec = rc_touch(static_cast<RcComm*>(conn), input.dump().c_str());
 
-					res.body() = json{{"irods_response", {{"error_code", ec}}}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1700,12 +1700,12 @@ namespace
 					auto conn = irods::get_connection(client_info.username);
 					const auto ec = rcDataObjChksum(static_cast<RcComm*>(conn), &input, &checksum);
 
-					res.body() = json{{"irods_response", {{"error_code", ec}}}, {"checksum", checksum}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", ec}}}, {"checksum", checksum}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1773,7 +1773,7 @@ namespace
 					auto conn = irods::get_connection(client_info.username);
 					const auto ec = rcDataObjChksum(static_cast<RcComm*>(conn), &input, &results);
 
-					json response{{"irods_response", {{"error_code", ec}}}};
+					json response{{"irods_response", {{"status_code", ec}}}};
 
 					if (ec == CHECK_VERIFICATION_RESULTS) {
 						response["results"] = json::parse(results);
@@ -1797,7 +1797,7 @@ namespace
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -1905,7 +1905,7 @@ namespace
 				auto conn = irods::get_connection(client_info.username);
 				const auto ec = rcModDataObjMeta(static_cast<RcComm*>(conn), &input);
 
-				json response{{"irods_response", {{"error_code", ec}}}};
+				json response{{"irods_response", {{"status_code", ec}}}};
 
 				res.body() = response.dump();
 			}
@@ -1915,8 +1915,8 @@ namespace
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
-						{"error_code", e.code()},
-						{"error_message", e.client_display_what()}
+						{"status_code", e.code()},
+						{"status_message", e.client_display_what()}
 					}}
 				}.dump();
 				// clang-format on

--- a/src/endpoints/data_objects/impl.cpp
+++ b/src/endpoints/data_objects/impl.cpp
@@ -417,18 +417,21 @@ namespace
 					res.body() = std::string_view(buffer.data(), in.gcount());
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -641,17 +644,20 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -751,6 +757,7 @@ namespace
 					}
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					log::error("{}: Could not open one or more output streams to [{}].", fn, lpath_iter->second);
 					res.result(http::status::internal_server_error);
 					res.prepare_payload();
@@ -792,17 +799,20 @@ namespace
 						.dump();
 			}
 			catch (const fs::filesystem_error& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -878,18 +888,21 @@ namespace
 						 }}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -958,12 +971,14 @@ namespace
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1030,12 +1045,14 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", ec < 0 ? ec : 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1115,17 +1132,20 @@ namespace
 					 }}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -1216,18 +1236,21 @@ namespace
 							.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1308,12 +1331,14 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1373,18 +1398,21 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1443,18 +1471,21 @@ namespace
 						 }}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1519,6 +1550,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"copied", copied}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response",
@@ -1528,12 +1560,14 @@ namespace
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1629,12 +1663,14 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1703,12 +1739,14 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", ec}}}, {"checksum", checksum}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1795,12 +1833,14 @@ namespace
 					res.body() = response.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1910,7 +1950,7 @@ namespace
 				res.body() = response.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: Caught exception: {}", fn, e.client_display_what());
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				// clang-format off
 				res.body() = json{
@@ -1922,7 +1962,7 @@ namespace
 				// clang-format on
 			}
 			catch (const std::exception& e) {
-				log::error("{}: Caught exception: {}", fn, e.what());
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/src/endpoints/data_objects/impl.cpp
+++ b/src/endpoints/data_objects/impl.cpp
@@ -393,7 +393,7 @@ namespace
 					const auto count = std::stoi(iter->second);
 
 					if (count > irods::http::globals::configuration()
-					                .at(json::json_pointer{"/irods_client/max_rbuffer_size_in_bytes"})
+					                .at(json::json_pointer{"/irods_client/max_number_of_bytes_per_read_operation"})
 					                .get<int>())
 					{
 						res.result(http::status::bad_request);
@@ -616,9 +616,9 @@ namespace
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
-				static const auto max_wbuffer_size =
+				static const auto buffer_size =
 					irods::http::globals::configuration()
-						.at(json::json_pointer{"/irods_client/max_wbuffer_size_in_bytes"})
+						.at(json::json_pointer{"/irods_client/buffer_size_in_bytes_for_write_operations"})
 						.get<std::int64_t>();
 				const char* p = iter->second.data();
 
@@ -629,7 +629,7 @@ namespace
 						return _sess_ptr->send(irods::http::fail(res, http::status::internal_server_error));
 					}
 
-					const auto to_send = std::min<std::streamsize>(remaining_bytes, max_wbuffer_size);
+					const auto to_send = std::min<std::streamsize>(remaining_bytes, buffer_size);
 					log::debug("{}: Write buffer: remaining=[{}], sending=[{}].", fn, remaining_bytes, to_send);
 					out_ptr->write(p, to_send);
 					p += to_send;

--- a/src/endpoints/information/impl.cpp
+++ b/src/endpoints/information/impl.cpp
@@ -58,7 +58,7 @@ namespace irods::http::handler
 			return _sess_ptr->send(std::move(res));
 		}
 		catch (const std::exception& e) {
-			log::error("{}: Caught exception while processing /info request: {}", __func__, e.what());
+			log::error("{}: {}", __func__, e.what());
 		}
 	} // information
 } //namespace irods::http::handler

--- a/src/endpoints/query/impl.cpp
+++ b/src/endpoints/query/impl.cpp
@@ -198,7 +198,7 @@ namespace
 
 						if (ec < 0) {
 							res.result(http::status::bad_request);
-							res.body() = json{{"irods_response", {{"error_code", ec}}}}.dump();
+							res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 						}
 
 						if (0 == input.sql_only) {
@@ -206,19 +206,19 @@ namespace
 							// because this avoids the need to parse the GenQuery2 results into an nlohmann
 							// JSON object just to serialize it for the response.
 							constexpr const auto* json_fmt_string =
-								R"_({{"irods_response":{{"error_code":0}},"rows":{}}})_";
+								R"_({{"irods_response":{{"status_code":0}},"rows":{}}})_";
 							res.body() = fmt::format(json_fmt_string, output);
 						}
 						else {
 							constexpr const auto* json_fmt_string =
-								R"_({{"irods_response":{{"error_code":0}},"sql":"{}"}})_";
+								R"_({{"irods_response":{{"status_code":0}},"sql":"{}"}})_";
 							res.body() = fmt::format(json_fmt_string, output);
 						}
 #else
 						res.result(http::status::bad_request);
 						res.body() = json{{"irods_response",
-					                       {{"error_code", 0},
-					                        {"error_message", "GenQuery2 not enabled. Use GenQuery1 parser."}}}}
+					                       {{"status_code", 0},
+					                        {"status_message", "GenQuery2 not enabled. Use GenQuery1 parser."}}}}
 					                     .dump();
 #endif // IRODS_ENABLE_GENQUERY2
 					}
@@ -275,7 +275,7 @@ namespace
 						res.body() = json{
 							{"irods_response",
 					         {
-								 {"error_code", 0},
+								 {"status_code", 0},
 							 }},
 							{"rows",
 					         rows}}.dump();
@@ -284,7 +284,7 @@ namespace
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -408,7 +408,7 @@ namespace
 				res.body() = json{
 					{"irods_response",
 				     {
-						 {"error_code", 0},
+						 {"status_code", 0},
 					 }},
 					{"rows",
 				     rows}}.dump();
@@ -416,7 +416,7 @@ namespace
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {

--- a/src/endpoints/query/impl.cpp
+++ b/src/endpoints/query/impl.cpp
@@ -202,9 +202,7 @@ namespace
 						}
 
 						if (0 == input.sql_only) {
-							// The string below contains a format placeholder for the "rows" property
-							// because this avoids the need to parse the GenQuery2 results into an nlohmann
-							// JSON object just to serialize it for the response.
+							// This is a performance optimization.
 							constexpr const auto* json_fmt_string =
 								R"_({{"irods_response":{{"status_code":0}},"rows":{}}})_";
 							res.body() = fmt::format(json_fmt_string, output);
@@ -284,9 +282,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());

--- a/src/endpoints/query/impl.cpp
+++ b/src/endpoints/query/impl.cpp
@@ -282,12 +282,14 @@ namespace
 					}
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -414,12 +416,14 @@ namespace
 				     rows}}.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/src/endpoints/resources/impl.cpp
+++ b/src/endpoints/resources/impl.cpp
@@ -184,13 +184,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -234,13 +234,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -277,8 +277,8 @@ namespace
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
-                        {"error_code", e.code()},
-                        {"error_message", e.client_display_what()}
+                        {"status_code", e.code()},
+                        {"status_message", e.client_display_what()}
                     }}
                 }.dump();
             }
@@ -343,13 +343,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -399,13 +399,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -449,13 +449,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -567,12 +567,12 @@ namespace
 					// clang-format on
 				}
 
-				res.body() = json{{"irods_response", {{"error_code", 0}}}, {"exists", exists}, {"info", info}}.dump();
+				res.body() = json{{"irods_response", {{"status_code", 0}}}, {"exists", exists}, {"info", info}}.dump();
 			}
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {

--- a/src/endpoints/resources/impl.cpp
+++ b/src/endpoints/resources/impl.cpp
@@ -190,9 +190,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -242,9 +242,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -355,9 +355,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -413,9 +413,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -465,9 +465,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());

--- a/src/endpoints/resources/impl.cpp
+++ b/src/endpoints/resources/impl.cpp
@@ -188,12 +188,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -238,12 +240,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -274,6 +278,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -283,6 +288,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -347,12 +353,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -403,12 +411,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -453,12 +463,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -570,12 +582,14 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}, {"exists", exists}, {"info", info}}.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/src/endpoints/rules/impl.cpp
+++ b/src/endpoints/rules/impl.cpp
@@ -220,13 +220,13 @@ namespace
 				}
 
 				res.body() =
-					json{{"irods_response", {{"error_code", ec}}}, {"stdout", stdout_output}, {"stderr", stderr_output}}
+					json{{"irods_response", {{"status_code", ec}}}, {"stdout", stdout_output}, {"stderr", stderr_output}}
 						.dump();
 			}
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
@@ -274,13 +274,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", ec},
+							 {"status_code", ec},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -357,13 +357,13 @@ namespace
 				}
 
 				res.body() =
-					json{{"irods_response", {{"error_code", ec}}}, {"rule_engine_plugin_instances", plugin_instances}}
+					json{{"irods_response", {{"status_code", ec}}}, {"rule_engine_plugin_instances", plugin_instances}}
 						.dump();
 			}
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {

--- a/src/endpoints/rules/impl.cpp
+++ b/src/endpoints/rules/impl.cpp
@@ -220,7 +220,8 @@ namespace
 				}
 
 				res.body() =
-					json{{"irods_response", {{"status_code", ec}}}, {"stdout", stdout_output}, {"stderr", stderr_output}}
+					json{
+						{"irods_response", {{"status_code", ec}}}, {"stdout", stdout_output}, {"stderr", stderr_output}}
 						.dump();
 			}
 			catch (const irods::exception& e) {
@@ -282,9 +283,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());

--- a/src/endpoints/rules/impl.cpp
+++ b/src/endpoints/rules/impl.cpp
@@ -224,12 +224,14 @@ namespace
 						.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -278,12 +280,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -361,12 +365,14 @@ namespace
 						.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/src/endpoints/shared_api_operations.cpp
+++ b/src/endpoints/shared_api_operations.cpp
@@ -73,7 +73,7 @@ namespace irods::http::shared_api_operations
 								return _sess_ptr->send(irods::http::fail(
 									res,
 									::http::status::bad_request,
-									json{{"irods_response", {{"error_code", NOT_A_DATA_OBJECT}}}}.dump()));
+									json{{"irods_response", {{"status_code", NOT_A_DATA_OBJECT}}}}.dump()));
 							}
 							break;
 
@@ -82,7 +82,7 @@ namespace irods::http::shared_api_operations
 								return _sess_ptr->send(irods::http::fail(
 									res,
 									::http::status::bad_request,
-									json{{"irods_response", {{"error_code", NOT_A_COLLECTION}}}}.dump()));
+									json{{"irods_response", {{"status_code", NOT_A_COLLECTION}}}}.dump()));
 							}
 							break;
 
@@ -111,7 +111,7 @@ namespace irods::http::shared_api_operations
 						res.result(::http::status::bad_request);
 					}
 
-					json response{{"irods_response", {{"error_code", ec}}}};
+					json response{{"irods_response", {{"status_code", ec}}}};
 
 					if (output) {
 						response.at("irods_response")["failed_operation"] = json::parse(output);
@@ -124,8 +124,8 @@ namespace irods::http::shared_api_operations
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}
 						}}
 					}.dump();
 					// clang-format on
@@ -224,7 +224,7 @@ namespace irods::http::shared_api_operations
 						res.result(::http::status::bad_request);
 					}
 
-					json response{{"irods_response", {{"error_code", ec}}}};
+					json response{{"irods_response", {{"status_code", ec}}}};
 
 					if (output) {
 						response.at("irods_response")["failed_operation"] = json::parse(output);
@@ -237,8 +237,8 @@ namespace irods::http::shared_api_operations
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}}
 						}
 					}.dump();
 					// clang-format on

--- a/src/endpoints/shared_api_operations.cpp
+++ b/src/endpoints/shared_api_operations.cpp
@@ -120,6 +120,7 @@ namespace irods::http::shared_api_operations
 					res.body() = response.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(::http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -131,6 +132,7 @@ namespace irods::http::shared_api_operations
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(::http::status::internal_server_error);
 				}
 
@@ -233,6 +235,7 @@ namespace irods::http::shared_api_operations
 					res.body() = response.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(::http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -244,6 +247,7 @@ namespace irods::http::shared_api_operations
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(::http::status::internal_server_error);
 				}
 

--- a/src/endpoints/tickets/impl.cpp
+++ b/src/endpoints/tickets/impl.cpp
@@ -143,8 +143,8 @@ namespace
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
-                        {"error_code", e.code()},
-                        {"error_message", e.client_display_what()}
+                        {"status_code", e.code()},
+                        {"status_message", e.client_display_what()}
                     }}
                 }.dump();
             }
@@ -188,8 +188,8 @@ namespace
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
-                        {"error_code", e.code()},
-                        {"error_message", e.client_display_what()}
+                        {"status_code", e.code()},
+                        {"status_message", e.client_display_what()}
                     }}
                 }.dump();
             }
@@ -318,7 +318,7 @@ namespace
 				res.body() = json{
 					{"irods_response",
 				     {
-						 {"error_code", 0},
+						 {"status_code", 0},
 					 }},
 					{"ticket",
 				     ticket}}.dump();
@@ -326,7 +326,7 @@ namespace
 			catch (const irods::exception& e) {
 				res.result(http::status::bad_request);
 				res.body() =
-					json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
@@ -370,13 +370,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {

--- a/src/endpoints/tickets/impl.cpp
+++ b/src/endpoints/tickets/impl.cpp
@@ -140,6 +140,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -149,6 +150,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -185,6 +187,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -194,6 +197,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -324,12 +328,14 @@ namespace
 				     ticket}}.dump();
 			}
 			catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -374,12 +380,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/src/endpoints/tickets/impl.cpp
+++ b/src/endpoints/tickets/impl.cpp
@@ -382,9 +382,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());

--- a/src/endpoints/users_groups/impl.cpp
+++ b/src/endpoints/users_groups/impl.cpp
@@ -206,7 +206,7 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							 {"error_code", 0}
+							 {"status_code", 0}
 						}}
 					}.dump();
 					// clang-format on
@@ -216,8 +216,8 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}
 						}}
 					}.dump();
 					// clang-format on
@@ -269,7 +269,7 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", 0}
+							{"status_code", 0}
 						}}
 					}.dump();
 					// clang-format on
@@ -279,8 +279,8 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}
 						}}
 					}.dump();
 					// clang-format on
@@ -341,15 +341,15 @@ namespace
 					auto conn = irods::get_connection(client_info.username);
 					adm::client::modify_user(conn, adm::user{name_iter->second, zone_iter->second}, prop);
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}
 						}}
 					}.dump();
 					// clang-format on
@@ -409,7 +409,7 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", 0}
+							{"status_code", 0}
 						}}
 					}.dump();
 					// clang-format on
@@ -419,8 +419,8 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}
 						}}
 					}.dump();
 					// clang-format on
@@ -459,8 +459,8 @@ namespace
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
-                        {"error_code", e.code()},
-                        {"error_message", e.client_display_what()}
+                        {"status_code", e.code()},
+                        {"status_message", e.client_display_what()}
                     }}
                 }.dump();
             }
@@ -504,8 +504,8 @@ namespace
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
-                        {"error_code", e.code()},
-                        {"error_message", e.client_display_what()}
+                        {"status_code", e.code()},
+                        {"status_message", e.client_display_what()}
                     }}
                 }.dump();
             }
@@ -556,7 +556,7 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", 0}
+							{"status_code", 0}
 						}}
 					}.dump();
 					// clang-format on
@@ -566,8 +566,8 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}
 						}}
 					}.dump();
 					// clang-format on
@@ -613,7 +613,7 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", 0}
+							{"status_code", 0}
 						}}
 					}.dump();
 					// clang-format on
@@ -623,8 +623,8 @@ namespace
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
-							{"error_code", e.code()},
-							{"error_message", e.client_display_what()}
+							{"status_code", e.code()},
+							{"status_message", e.client_display_what()}
 						}}
 					}.dump();
 					// clang-format on
@@ -683,13 +683,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -746,13 +746,13 @@ namespace
 					res.body() = json{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -794,12 +794,12 @@ namespace
 						v.push_back({{"name", u.name}, {"zone", u.zone}});
 					}
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}, {"users", v}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"users", v}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -841,12 +841,12 @@ namespace
 						v.push_back(std::move(g.name));
 					}
 
-					res.body() = json{{"irods_response", {{"error_code", 0}}}, {"groups", v}}.dump();
+					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"groups", v}}.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -883,8 +883,8 @@ namespace
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
-                        {"error_code", e.code()},
-                        {"error_message", e.client_display_what()}
+                        {"status_code", e.code()},
+                        {"status_message", e.client_display_what()}
                     }}
                 }.dump();
             }
@@ -948,14 +948,14 @@ namespace
 
 					res.body() =
 						json{
-							{"irods_response", {{"error_code", 0}}},
+							{"irods_response", {{"status_code", 0}}},
 							{"is_member", adm::client::user_is_member_of_group(conn, group, user)}}
 							.dump();
 				}
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
@@ -998,7 +998,7 @@ namespace
 					json info{
 						{"irods_response",
 				         {
-							 {"error_code", 0},
+							 {"status_code", 0},
 						 }},
 						{"exists", false}};
 
@@ -1043,7 +1043,7 @@ namespace
 				catch (const irods::exception& e) {
 					res.result(http::status::bad_request);
 					res.body() =
-						json{{"irods_response", {{"error_code", e.code()}, {"error_message", e.client_display_what()}}}}
+						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {

--- a/src/endpoints/users_groups/impl.cpp
+++ b/src/endpoints/users_groups/impl.cpp
@@ -705,9 +705,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -770,9 +770,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -819,9 +819,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -868,9 +868,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -981,9 +981,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());
@@ -1071,9 +1071,9 @@ namespace
 				catch (const irods::exception& e) {
 					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
-					res.body() =
-						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
-							.dump();
+					res.body() = json{{"irods_response",
+				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
+				                     .dump();
 				}
 				catch (const std::exception& e) {
 					log::error("{}: {}", fn, e.what());

--- a/src/endpoints/users_groups/impl.cpp
+++ b/src/endpoints/users_groups/impl.cpp
@@ -212,6 +212,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -223,6 +224,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -275,6 +277,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -286,6 +289,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -344,6 +348,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -355,6 +360,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -415,6 +421,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -426,6 +433,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -456,6 +464,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -465,6 +474,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -501,6 +511,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -510,6 +521,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -562,6 +574,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -573,6 +586,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -619,6 +633,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					// clang-format off
 					res.body() = json{
@@ -630,6 +645,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -687,12 +703,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -750,12 +768,14 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -797,12 +817,14 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"users", v}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -844,12 +866,14 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"groups", v}}.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -880,6 +904,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
+				log::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -889,6 +914,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
+				log::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -953,12 +979,14 @@ namespace
 							.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -1041,12 +1069,14 @@ namespace
 					res.body() = info.dump();
 				}
 				catch (const irods::exception& e) {
+					log::error("{}: {}", fn, e.client_display_what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 							.dump();
 				}
 				catch (const std::exception& e) {
+					log::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/src/endpoints/zones/impl.cpp
+++ b/src/endpoints/zones/impl.cpp
@@ -70,7 +70,7 @@ namespace irods::http::handler
 
 			try {
 				res.body() = fmt::format(
-					R"_irods_({{"irods_response":{{"error_code":0}},"zone_report":{}}})_irods_",
+					R"_irods_({{"irods_response":{{"status_code":0}},"zone_report":{}}})_irods_",
 					std::string_view(static_cast<char*>(bbuf->buf), bbuf->len));
 			}
 			catch (const std::exception& e) {

--- a/src/endpoints/zones/impl.cpp
+++ b/src/endpoints/zones/impl.cpp
@@ -67,7 +67,16 @@ namespace irods::http::handler
 			res.set(field_type::server, irods::http::version::server_name);
 			res.set(field_type::content_type, "application/json");
 			res.keep_alive(_req.keep_alive());
-			res.body() = std::string_view(static_cast<char*>(bbuf->buf), bbuf->len);
+
+			try {
+				res.body() = fmt::format(
+					R"_irods_({{"irods_response":{{"error_code":0}},"zone_report":{}}})_irods_",
+					std::string_view(static_cast<char*>(bbuf->buf), bbuf->len));
+			}
+			catch (const std::exception& e) {
+				log::error("{}: Caught exception while writing zone report to HTTP body: {}", fn, e.what());
+			}
+
 			res.prepare_payload();
 
 			return _sess_ptr->send(std::move(res));

--- a/src/endpoints/zones/impl.cpp
+++ b/src/endpoints/zones/impl.cpp
@@ -74,7 +74,7 @@ namespace irods::http::handler
 					std::string_view(static_cast<char*>(bbuf->buf), bbuf->len));
 			}
 			catch (const std::exception& e) {
-				log::error("{}: Caught exception while writing zone report to HTTP body: {}", fn, e.what());
+				log::error("{}: {}", fn, e.what());
 			}
 
 			res.prepare_payload();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -594,10 +594,10 @@ auto main(int _argc, char* _argv[]) -> int
 	}
 	catch (const irods::exception& e) {
 		fmt::print(stderr, "Error: {}\n", e.client_display_what());
-		return 1;
 	}
 	catch (const std::exception& e) {
 		fmt::print(stderr, "Error: {}\n", e.what());
-		return 1;
 	}
+
+	return 1;
 } // main

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,8 +236,8 @@ auto print_configuration_template() -> void
 
         "max_number_of_parallel_write_streams": 3,
 
-        "max_rbuffer_size_in_bytes": 8192,
-        "max_wbuffer_size_in_bytes": 8192,
+        "max_number_of_bytes_per_read_operation": 8192,
+        "buffer_size_in_bytes_for_write_operations": 8192,
 
         "max_number_of_rows_per_catalog_query": 15
     }}

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -35,6 +35,11 @@ namespace irods::http
 	{
 	} // session (constructor)
 
+	auto session::ip() const -> std::string
+	{
+		return stream_.socket().remote_endpoint().address().to_string();
+	} // ip
+
 	// Start the asynchronous operation
 	auto session::run() -> void
 	{

--- a/src/session.hpp
+++ b/src/session.hpp
@@ -28,6 +28,8 @@ namespace irods::http
 			int _max_rbuffer_size,
 			int _timeout_in_seconds);
 
+		auto ip() const -> std::string;
+
 		auto run() -> void;
 
 		auto do_read() -> void;

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -147,7 +147,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
 
         # Stat the collection to show that it exists.
         params = {'op': 'stat', 'lpath': collection_path}
@@ -156,7 +156,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
 
         # Rename the collection.
         new_collection_path = collection_path + '.renamed'
@@ -193,7 +193,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(len(stat_info['permissions']), 2)
 
         perms = stat_info['permissions']
@@ -216,7 +216,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 400)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], -170000)
+        self.assertEqual(stat_info['irods_response']['status_code'], -170000)
 
     def test_stat_operation_returns_expected_json_structure(self):
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
@@ -226,7 +226,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(stat_info['type'], 'collection')
         self.assertEqual(stat_info['inheritance_enabled'], False)
         self.assertEqual(stat_info['registered'], True)
@@ -247,7 +247,7 @@ class test_collections_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.json()['irods_response']['error_code'], -170000)
+        self.assertEqual(r.json()['irods_response']['status_code'], -170000)
 
     def test_list_operation(self):
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
@@ -258,7 +258,7 @@ class test_collections_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data={'op': 'create', 'lpath': collection})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Create one data object in each collection.
         data_objects = [
@@ -272,14 +272,14 @@ class test_collections_endpoint(unittest.TestCase):
             r = requests.post(f'{self.url_base}/data-objects', headers=headers, data={'op': 'touch', 'lpath': data_object})
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.json()['irods_response']['error_code'], 0)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # List only the contents of the home collection.
         r = requests.get(self.url_endpoint, headers=headers, params={'op': 'list', 'lpath': home_collection})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['entries'], [os.path.dirname(data_objects[0])])
 
         # List the home collection recursively.
@@ -287,7 +287,7 @@ class test_collections_endpoint(unittest.TestCase):
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         result['entries'].sort()
         expected_result = [
             os.path.dirname(data_objects[0]),
@@ -309,7 +309,7 @@ class test_collections_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     def test_modifying_metadata_atomically(self):
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
@@ -330,7 +330,7 @@ class test_collections_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata exists on the collection.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -341,7 +341,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], collection)
 
         # Remove the metadata from the collection.
@@ -359,7 +359,7 @@ class test_collections_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata no longer exists on the collection.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -370,7 +370,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 0)
 
     def test_modifying_permissions_atomically(self):
@@ -390,7 +390,7 @@ class test_collections_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the rodsadmin now has permission to read the collection.
         r = requests.get(self.url_endpoint, headers=headers, params={
@@ -401,7 +401,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['permissions']), 2)
         #self.assertEqual(result['permissions'][0]['name'], self.rodsuser_username)
         #self.assertEqual(result['permissions'][0]['zone'], self.zone_name)
@@ -421,7 +421,7 @@ class test_collections_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the permissions have been removed.
         r = requests.get(self.url_endpoint, headers=headers, params={
@@ -432,7 +432,7 @@ class test_collections_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['permissions']), 1)
         #self.assertEqual(result['permissions'][0]['name'], self.rodsuser_username)
         #self.assertEqual(result['permissions'][0]['zone'], self.zone_name)
@@ -471,7 +471,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Create a non-empty data object.
         data_object = os.path.join('/', self.zone_name, 'home', self.rodsuser_username, 'common_ops.txt')
@@ -484,7 +484,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Replicate the data object.
         r = requests.post(self.url_endpoint, headers=rodsuser_headers, data={
@@ -494,7 +494,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show there are two replicas.
         coll_name = os.path.dirname(data_object)
@@ -506,7 +506,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 2)
 
         # Trim the first replica.
@@ -517,7 +517,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Rename the data object.
         data_object_renamed = f'{data_object}.renamed'
@@ -528,7 +528,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Copy the data object.
         data_object_copied = f'{data_object}.copied'
@@ -539,7 +539,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Modify permissions on the data object.
         r = requests.post(self.url_endpoint, headers=rodsuser_headers, data={
@@ -550,14 +550,14 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the permissions were updated.
         r = requests.get(self.url_endpoint, headers=rodsuser_headers, params={'op': 'stat', 'lpath': data_object_copied})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertIn({
             'name': self.rodsadmin_username,
             'zone': self.zone_name,
@@ -571,13 +571,13 @@ class test_data_objects_endpoint(unittest.TestCase):
                 r = requests.post(self.url_endpoint, headers=rodsuser_headers, data={'op': 'remove', 'lpath': data_object, 'no-trash': 1})
                 #print(r.content) # Debug
                 self.assertEqual(r.status_code, 200)
-                self.assertEqual(r.json()['irods_response']['error_code'], 0)
+                self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Remove the resource.
         r = requests.post(f'{self.url_base}/resources', headers=rodsadmin_headers, data={'op': 'remove', 'name': resc_name})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     def test_registering_a_new_data_object(self):
         rodsadmin_headers = {'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}
@@ -597,7 +597,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             })
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 400)
-            self.assertEqual(r.json()['irods_response']['error_code'], -171000)
+            self.assertEqual(r.json()['irods_response']['status_code'], -171000)
 
             # Register the local file into the catalog as a new data object.
             # We know we're registering a new data object because the "as-additional-replica"
@@ -611,7 +611,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             })
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.json()['irods_response']['error_code'], 0)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
             # Show a new data object exists with the expected replica information.
             r = requests.get(f'{self.url_base}/query', headers=rodsadmin_headers, params={
@@ -621,7 +621,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 200)
             result = r.json()
-            self.assertEqual(result['irods_response']['error_code'], 0)
+            self.assertEqual(result['irods_response']['status_code'], 0)
             self.assertEqual(len(result['rows']), 1)
             self.assertEqual(result['rows'][0][0], os.path.dirname(data_object))
             self.assertEqual(result['rows'][0][1], filename)
@@ -656,7 +656,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             })
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.json()['irods_response']['error_code'], 0)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
             # Create a new unixfilesystem resource.
             r = requests.post(f'{self.url_base}/resources', headers=rodsadmin_headers, data={
@@ -668,7 +668,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             })
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.json()['irods_response']['error_code'], 0)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
             # Create a local file.
             physical_path = f'/tmp/{filename}'
@@ -685,7 +685,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             })
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 200)
-            self.assertEqual(r.json()['irods_response']['error_code'], 0)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
             # Show a new replica exists with the expected replica information.
             r = requests.get(f'{self.url_base}/query', headers=rodsadmin_headers, params={
@@ -696,7 +696,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             #print(r.content) # Debug
             self.assertEqual(r.status_code, 200)
             result = r.json()
-            self.assertEqual(result['irods_response']['error_code'], 0)
+            self.assertEqual(result['irods_response']['status_code'], 0)
             self.assertEqual(len(result['rows']), 1)
             self.assertEqual(result['rows'][0][0], os.path.dirname(data_object))
             self.assertEqual(result['rows'][0][1], filename)
@@ -727,7 +727,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 400)
-        self.assertEqual(r.json()['irods_response']['error_code'], -171000)
+        self.assertEqual(r.json()['irods_response']['status_code'], -171000)
 
     def multipart_form_data_upload(self, **args):
         boundary = '------testing_http_api------'
@@ -778,7 +778,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         parallel_write_handle = result['parallel_write_handle']
 
         # Write to the data object using the parallel write handle.
@@ -801,7 +801,7 @@ class test_data_objects_endpoint(unittest.TestCase):
             for f in concurrent.futures.as_completed(futures):
                 result = f.result()
                 #print(result) # Debug
-                self.assertEqual(result['irods_response']['error_code'], 0)
+                self.assertEqual(result['irods_response']['status_code'], 0)
 
         # End the parallel write.
         r = requests.post(self.url_endpoint, headers=headers, data={
@@ -810,7 +810,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Read the contents of the data object and show it contains exactly what we expect.
         r = requests.get(self.url_endpoint, headers=headers, params={
@@ -826,7 +826,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data={'op': 'remove', 'lpath': data_object, 'no-trash': 1})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     def test_modifying_metadata_atomically(self):
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
@@ -839,7 +839,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Add metadata to the home data object.
         r = requests.post(self.url_endpoint, headers=headers, data={
@@ -856,7 +856,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata exists on the data object.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -867,7 +867,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], os.path.dirname(data_object))
         self.assertEqual(result['rows'][0][1], os.path.basename(data_object))
 
@@ -886,7 +886,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata no longer exists on the data object.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -897,7 +897,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 0)
 
         # Remove the data object.
@@ -908,7 +908,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     def test_modifying_permissions_atomically(self):
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
@@ -921,7 +921,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Give the rodsadmin read permission on the data object.
         r = requests.post(self.url_endpoint, headers=headers, data={
@@ -936,7 +936,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the rodsadmin now has permission to read the data object.
         r = requests.get(self.url_endpoint, headers=headers, params={
@@ -947,7 +947,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['permissions']), 2)
         #self.assertEqual(result['permissions'][0]['name'], self.rodsuser_username)
         #self.assertEqual(result['permissions'][0]['zone'], self.zone_name)
@@ -967,7 +967,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the permissions have been removed.
         r = requests.get(self.url_endpoint, headers=headers, params={
@@ -978,7 +978,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['permissions']), 1)
         #self.assertEqual(result['permissions'][0]['name'], self.rodsuser_username)
         #self.assertEqual(result['permissions'][0]['zone'], self.zone_name)
@@ -993,7 +993,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     def test_modifying_replica_properties(self):
         headers = {'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}
@@ -1006,7 +1006,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the replica is currently marked as good and has a size of 0.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1017,7 +1017,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], '1')
         self.assertEqual(result['rows'][0][1], '0')
 
@@ -1031,7 +1031,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the replica's status and size has changed in the catalog.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1042,7 +1042,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], '0')
         self.assertEqual(result['rows'][0][1], '15')
 
@@ -1054,7 +1054,7 @@ class test_data_objects_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     @unittest.skip('Test needs to be implemented.')
     def test_return_error_on_missing_parameters(self):
@@ -1104,7 +1104,7 @@ class test_query_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertGreater(len(result['rows']), 0)
 
     def test_genquery2_query(self):
@@ -1121,7 +1121,7 @@ class test_query_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertGreater(len(result['rows']), 0)
         self.assertIn(['/tempZone/home/http_api'], result['rows'])
         self.assertIn(['/tempZone/trash/home/http_api'], result['rows'])
@@ -1141,7 +1141,7 @@ class test_query_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertGreater(len(result['sql']), 0)
 
     def test_support_for_specific_queries(self):
@@ -1157,7 +1157,7 @@ class test_query_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertGreaterEqual(len(result['rows']), 0)
 
 class test_resources_endpoint(unittest.TestCase):
@@ -1191,7 +1191,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Show the replication resource was created.
         r = requests.get(self.url_endpoint, headers=headers, params={'op': 'stat', 'name': resc_repl})
@@ -1199,7 +1199,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['exists'], True)
         self.assertIn('id', result['info'])
         self.assertEqual(result['info']['name'], resc_repl)
@@ -1237,7 +1237,7 @@ class test_resources_endpoint(unittest.TestCase):
                 })
                 #print(r.content) # Debug
                 self.assertEqual(r.status_code, 200)
-                self.assertEqual(r.json()['irods_response']['error_code'], 0)
+                self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
                 # Add the unixfilesystem resource as a child of the replication resource.
                 r = requests.post(self.url_endpoint, headers=headers, data={
@@ -1247,7 +1247,7 @@ class test_resources_endpoint(unittest.TestCase):
                 })
                 #print(r.content) # Debug
                 self.assertEqual(r.status_code, 200)
-                self.assertEqual(r.json()['irods_response']['error_code'], 0)
+                self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
                 # Show that the resource was created and configured successfully.
                 r = requests.get(self.url_endpoint, headers=headers, params={'op': 'stat', 'name': resc_name})
@@ -1255,7 +1255,7 @@ class test_resources_endpoint(unittest.TestCase):
                 self.assertEqual(r.status_code, 200)
 
                 result = r.json()
-                self.assertEqual(result['irods_response']['error_code'], 0)
+                self.assertEqual(result['irods_response']['status_code'], 0)
                 self.assertEqual(result['exists'], True)
                 self.assertIn('id', result['info'])
                 self.assertEqual(result['info']['name'], resc_name)
@@ -1286,7 +1286,7 @@ class test_resources_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show there are two replicas under the replication resource hierarchy.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1297,7 +1297,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 2)
 
         resc_tuple = (result['rows'][0][1], result['rows'][1][1])
@@ -1314,7 +1314,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Show there is only one replica under the replication resource hierarchy.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1325,7 +1325,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 1)
 
         # Launch rebalance.
@@ -1334,7 +1334,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Give the rebalance operation time to complete!
         time.sleep(3)
@@ -1353,7 +1353,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Remove resources.
         for resc_name in [resc_ufs0, resc_ufs1]:
@@ -1368,7 +1368,7 @@ class test_resources_endpoint(unittest.TestCase):
                 self.assertEqual(r.status_code, 200)
 
                 result = r.json()
-                self.assertEqual(result['irods_response']['error_code'], 0)
+                self.assertEqual(result['irods_response']['status_code'], 0)
 
                 # Remove ufs resource.
                 r = requests.post(self.url_endpoint, headers=headers, data={'op': 'remove', 'name': resc_name})
@@ -1376,7 +1376,7 @@ class test_resources_endpoint(unittest.TestCase):
                 self.assertEqual(r.status_code, 200)
 
                 result = r.json()
-                self.assertEqual(result['irods_response']['error_code'], 0)
+                self.assertEqual(result['irods_response']['status_code'], 0)
 
                 # Show that the resource no longer exists.
                 r = requests.get(self.url_endpoint, headers=headers, params={'op': 'stat', 'name': resc_name})
@@ -1384,7 +1384,7 @@ class test_resources_endpoint(unittest.TestCase):
                 self.assertEqual(r.status_code, 200)
 
                 result = r.json()
-                self.assertEqual(result['irods_response']['error_code'], 0)
+                self.assertEqual(result['irods_response']['status_code'], 0)
                 self.assertEqual(result['exists'], False)
 
         # Remove replication resource.
@@ -1393,7 +1393,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Show that the resource no longer exists.
         r = requests.get(self.url_endpoint, headers=headers, params={'op': 'stat', 'name': resc_repl})
@@ -1401,7 +1401,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['exists'], False)
 
     def test_modifying_metadata_atomically(self):
@@ -1423,7 +1423,7 @@ class test_resources_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata exists on the resource.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1434,7 +1434,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], resource)
 
         # Remove the metadata from the resource.
@@ -1452,7 +1452,7 @@ class test_resources_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata no longer exists on the resource.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1463,7 +1463,7 @@ class test_resources_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 0)
 
 class test_rules_endpoint(unittest.TestCase):
@@ -1486,7 +1486,7 @@ class test_rules_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertGreater(len(result['rule_engine_plugin_instances']), 0)
 
     def test_execute_rule(self):
@@ -1503,7 +1503,7 @@ class test_rules_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
  
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['stderr'], None)
 
         # The REP always appends a newline character to the result. While we could trim the result,
@@ -1524,7 +1524,7 @@ class test_rules_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
  
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Find the delay rule we just created.
         # This query assumes the test suite is running on a system where no other delay
@@ -1537,7 +1537,7 @@ class test_rules_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
  
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 1)
 
         # Remove the delay rule.
@@ -1549,7 +1549,7 @@ class test_rules_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
  
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
 class test_tickets_endpoint(unittest.TestCase):
 
@@ -1574,7 +1574,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Create a ticket.
         ticket_type = 'read'
@@ -1589,7 +1589,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         ticket_string = result['ticket']
         self.assertGreater(len(ticket_string), 0)
 
@@ -1604,7 +1604,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], ticket_string)
         self.assertEqual(result['rows'][0][1], ticket_type)
         self.assertEqual(result['rows'][0][2], os.path.basename(data_object))
@@ -1616,7 +1616,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Show the ticket no longer exists.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1627,7 +1627,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 0)
 
         # Remove the data object.
@@ -1640,7 +1640,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
     def test_create_and_remove_ticket_for_collection(self):
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
@@ -1665,7 +1665,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         ticket_string = result['ticket']
         self.assertGreater(len(ticket_string), 0)
 
@@ -1680,7 +1680,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], ticket_string)
         self.assertEqual(result['rows'][0][1], ticket_type)
         self.assertEqual(result['rows'][0][2], ticket_path)
@@ -1695,7 +1695,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         # Show the ticket no longer exists.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -1706,7 +1706,7 @@ class test_tickets_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 0)
 
     @unittest.skip('Test and HTTP API operation need to be implemented.')
@@ -1744,7 +1744,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(stat_info['exists'], True)
         self.assertIn('id', stat_info)
         self.assertEqual(stat_info['local_unique_name'], f'{new_username}#{self.zone_name}')
@@ -1774,7 +1774,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(stat_info['exists'], True)
         self.assertIn('id', stat_info)
         self.assertEqual(stat_info['local_unique_name'], f'{new_username}#{self.zone_name}')
@@ -1804,7 +1804,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(stat_info['exists'], True)
         self.assertIn('id', stat_info)
         self.assertEqual(stat_info['local_unique_name'], f'{new_username}#{self.zone_name}')
@@ -1825,7 +1825,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Stat the group.
         params = {'op': 'stat', 'name': new_group}
@@ -1834,7 +1834,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(stat_info['exists'], True)
         self.assertIn('id', stat_info)
         self.assertEqual(stat_info['type'], 'rodsgroup')
@@ -1846,14 +1846,14 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
  
         # Add user to group.
         data = {'op': 'add_to_group', 'group': new_group, 'user': new_username, 'zone': self.zone_name}
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show that the user is a member of the group.
         params = {'op': 'is_member_of_group', 'group': new_group, 'user': new_username, 'zone': self.zone_name}
@@ -1861,7 +1861,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['is_member'], True)
 
         # Remove user from group.
@@ -1869,31 +1869,31 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Remove the user.
         data = {'op': 'remove_user', 'name': new_username, 'zone': self.zone_name}
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Remove group.
         data = {'op': 'remove_group', 'name': new_group}
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show that the group no longer exists.
         params = {'op': 'stat', 'name': new_group}
         r = requests.get(self.url_endpoint, headers=headers, params=params)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(stat_info['exists'], False)
 
     def test_only_a_rodsadmin_can_change_the_type_of_a_user(self):
@@ -1906,7 +1906,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show that a rodsadmin can change the type of the new user.
         new_user_type = 'groupadmin'
@@ -1914,7 +1914,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show that a non-admin cannot change the new user's password.
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
@@ -1922,7 +1922,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 400)
-        self.assertNotEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertNotEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show that the user type matches the type set by the rodsadmin.
         params = {'op': 'stat', 'name': new_username, 'zone': self.zone_name}
@@ -1931,7 +1931,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         stat_info = r.json()
-        self.assertEqual(stat_info['irods_response']['error_code'], 0)
+        self.assertEqual(stat_info['irods_response']['status_code'], 0)
         self.assertEqual(stat_info['exists'], True)
         self.assertEqual(stat_info['local_unique_name'], f'{new_username}#{self.zone_name}')
         self.assertEqual(stat_info['type'], new_user_type)
@@ -1942,7 +1942,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data=data)
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     def test_rodsusers_cannot_change_passwords(self):
         headers = {'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}
@@ -1957,7 +1957,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 400)
-        self.assertNotEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertNotEqual(r.json()['irods_response']['status_code'], 0)
 
         # Authenticate as the user to prove the first password modification was successful.
         r = requests.post(f'{self.url_base}/authenticate', auth=(self.rodsuser_username, config.test_config['rodsuser']['password']))
@@ -1969,7 +1969,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertIn({'name': self.rodsadmin_username, 'zone': self.zone_name}, result['users'])
         self.assertIn({'name': self.rodsuser_username, 'zone': self.zone_name}, result['users'])
 
@@ -1981,14 +1981,14 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data={'op': 'create_group', 'name': new_group})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Get all groups.
         r = requests.get(self.url_endpoint, headers={'Authorization': f'Bearer {self.rodsuser_bearer_token}'}, params={'op': 'groups'})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertIn('public', result['groups'])
         self.assertIn(new_group, result['groups'])
 
@@ -1996,7 +1996,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         r = requests.post(self.url_endpoint, headers=headers, data={'op': 'remove_group', 'name': new_group})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
     def test_modifying_metadata_atomically(self):
         headers = {'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}
@@ -2017,7 +2017,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata exists on the user.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -2028,7 +2028,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(result['rows'][0][0], username)
 
         # Remove the metadata from the user.
@@ -2046,7 +2046,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         })
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['error_code'], 0)
+        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
         # Show the metadata no longer exists on the user.
         r = requests.get(f'{self.url_base}/query', headers=headers, params={
@@ -2057,7 +2057,7 @@ class test_users_groups_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
         self.assertEqual(len(result['rows']), 0)
 
     @unittest.skip('Test needs to be implemented.')
@@ -2120,7 +2120,7 @@ class test_zones_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
 
         result = r.json()
-        self.assertEqual(result['irods_response']['error_code'], 0)
+        self.assertEqual(result['irods_response']['status_code'], 0)
 
         zone_report = result['zone_report']
         self.assertIn('schema_version', zone_report)

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -2115,12 +2115,14 @@ class test_zones_endpoint(unittest.TestCase):
 
     def test_report_operation(self):
         headers = {'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}
-        params = {'op': 'report'}
-        r = requests.get(self.url_endpoint, headers=headers, params=params)
+        r = requests.get(self.url_endpoint, headers=headers, params={'op': 'report'})
         #print(r.content) # Debug
         self.assertEqual(r.status_code, 200)
 
-        zone_report = r.json()
+        result = r.json()
+        self.assertEqual(result['irods_response']['error_code'], 0)
+
+        zone_report = result['zone_report']
         self.assertIn('schema_version', zone_report)
         self.assertIn('zones', zone_report)
         self.assertGreaterEqual(len(zone_report['zones']), 1)


### PR DESCRIPTION
All tests pass.

Changing the response structure required formatting lots of code. Consider looking at each commit in isolation. The last commit is just formatting + one code comment adjustment.

Client IP addresses aren't logged yet, but this PR makes it possible to capture them. I haven't decided how to handle that. Still thinking through the design and implementation. Logging IPs is looking like a 0.2.0 thing.