### PR TITLE
Add support for the anonymous user account and record python dependencies for testing

### DIFF
--- a/API.md
+++ b/API.md
@@ -8,13 +8,15 @@ If you discover that some topic related to the behavior of the endpoint operatio
 
 ### Scheme: Basic
 
-_Command:_
+#### Request
+
 ```bash
-curl http://localhost:<port>/irods-http-api/<version>/authenticate \
-    -X POST --user <username>:<password> 
+curl -X POST -u <username>:<password> http://localhost:<port>/irods-http-api/<version>/authenticate
 ```
 
-_Returns:_ A string representing a bearer token that can be used to carry out operations as the authenticated user.
+#### Response
+
+A string representing a bearer token that can be used to execute operations as the authenticated user.
 
 ### Scheme: OpenID Connect (OIDC)
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -380,9 +380,9 @@ namespace irods
 		std::strncpy(input.zone, zone.c_str(), sizeof(SwitchUserInput::zone));
 		addKeyVal(&input.options, KW_CLOSE_OPEN_REPLICAS, "");
 
-		if (const auto ec = rc_switch_user(static_cast<RcComm*>(conn), &input); ec != 0) {
+		if (const auto ec = rc_switch_user(static_cast<RcComm*>(conn), &input); ec < 0) {
 			log::error("{}: rc_switch_user error: {}", __func__, ec);
-			THROW(SYS_INTERNAL_ERR, "rc_switch_user error.");
+			THROW(ec, "rc_switch_user error.");
 		}
 
 		log::trace("{}: Successfully changed identity associated with connection to [{}].", __func__, _username);

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -55,7 +55,6 @@ namespace irods::http
 	{
 		authorization_scheme auth_scheme;
 		std::string username;
-		std::string password; // TODO Probably not needed.
 		std::chrono::steady_clock::time_point
 			expires_at; // TODO This may be controlled by OIDC. Think about how to handle that.
 		// TODO Store an expiration timestamp here. Post discush: let it expire and send reauth code to client.

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2023.7.22
+charset-normalizer==3.3.2
+idna==3.4
+requests==2.31.0
+urllib3==2.0.7


### PR DESCRIPTION
All tests pass with this change.

Also, the server is now detecting the absence of the anonymous user and reporting the appropriate error. I think the original behavior I was seeing was due to old build artifacts. Recompiling from scratch resolved the issue.
