### PR TITLE
Update OIDC configuration, use boost url

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,15 +249,12 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
             },
 
             // Defines required OIDC related configuration.
-            "oidc": {
-                // The hostname or ip address of the OIDC provider.
-                "config_host": "oidc.example.org",
-
-                // The port the OIDC provider is listening on.
-                "port": 8080,
-
-                // Well known endpoint to retrieve configuration of OIDC provider.
-                "well_known_uri": "/realms/example",
+            "openid_connect": {
+                // The url of the OIDC provider, with a path leading to
+                // where the .well-known configuration is.
+                // The protocol will determine the default port used if
+                // none is specified in the url.
+                "provider_url": "https://oidc.example.org/realms/irods",
 
                 // The client id given to the application by OIDC provider.
                 "client_id": "irods_http_api",

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   irods_client
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so"
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_program_options.so"
+  "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_url.so"
   "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
   CURL::libcurl
 )

--- a/core/include/irods/private/http_api/common.hpp
+++ b/core/include/irods/private/http_api/common.hpp
@@ -11,6 +11,7 @@
 #include <boost/beast/http/status.hpp>
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
+#include <boost/url/parse.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -161,6 +162,8 @@ namespace irods::http
 		request_type& _req,
 		const std::unordered_map<std::string, handler_type>& _op_table_get,
 		const std::unordered_map<std::string, handler_type>& _op_table_post) -> void;
+
+	auto get_port_from_url(boost::urls::url_view _url) -> std::optional<std::string>;
 } // namespace irods::http
 
 namespace irods

--- a/core/src/common.cpp
+++ b/core/src/common.cpp
@@ -328,6 +328,25 @@ namespace irods::http
 		log::error("{}: HTTP method not supported.", __func__);
 		return _sess_ptr->send(irods::http::fail(status_type::method_not_allowed));
 	} // operation_dispatch
+
+	auto get_port_from_url(boost::urls::url_view _url) -> std::optional<std::string>
+	{
+		if (_url.has_port()) {
+			return _url.port();
+		}
+
+		switch (_url.scheme_id()) {
+			case boost::urls::scheme::https:
+				log::debug("{}: Detected HTTPS scheme, using port 443.", __func__);
+				return "443";
+			case boost::urls::scheme::http:
+				log::debug("{}: Detected HTTP scheme, using port 80.", __func__);
+				return "80";
+			default:
+				log::error("{}: Cannot deduce port from url [{}].", __func__, _url.data());
+				return std::nullopt;
+		}
+	} // get_port_from_url
 } // namespace irods::http
 
 namespace irods


### PR DESCRIPTION
Simplify OIDC configuration by using one 'provider_url', instead of three different parameters.

Additionally, use boost url in the parsing of OIDC urls.