### PR TITLE
[#164] Implement TLS/SSL OIDC communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,13 +424,11 @@ Following are a few points of interest.
 
 #### OpenID Provider Requirements and HTTP API Configuration
 The OpenID Provider, at this moment, must support discovery via a well-known endpoint.
-This endpoint must be specified in the `well_known_uri` OIDC configuration parameter.
+The URL to the OpenID Provider must be specified in the `provider_url` OIDC configuration parameter.
 
 One should take care to ensure that `/.well-known/openid-configuration` is not included
 in the configuration parameter, as this is included automatically.
 
-One must also set the OIDC `config_host` and `port` parameter, so that the OpenID configuration
-may be gathered from the well-known endpoint on the HTTP API server's startup.
 The OpenID Provider must be running prior to starting the HTTP API server, otherwise, the HTTP API server
 will not be able to query the required information from the desired OpenID Provider.
 
@@ -438,13 +436,13 @@ Additionally, the OIDC `redirect_uri` parameter must be set to the HTTP API's au
 This is required, as the Authorization Code Grant needs to be redirected back to the HTTP API, to complete
 HTTP API token generation.
 
-#### Add `irods_username` to the claims
-Currently, the server looks for the custom claim `irods_username` in the ID Token.
+#### Add your specified `irods_user_claim` to the user's claims
+Currently, the server looks for the custom claim in the ID Token, which is specified in the `irods_user_claim` parameter.
 This serves as the mapping mechanism for an OIDC User to an iRODS User.
 
-A user who authenticates but does not have a `irods_username` mapped in their account
+A user who authenticates but does not have the claim specified in `irods_user_claim` mapped in their account
 will not have access to the API.
-A HTTP 400 Bad Request status code will be returned if no `irods_username` is found.
+A HTTP 400 Bad Request status code will be returned if the claim specified in `irods_user_claim` is not found.
 
 #### Supported Grants
 Currently, the HTTP API server supports the following two grants:

--- a/README.md
+++ b/README.md
@@ -264,11 +264,15 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
 
                 // The amount of time before the OIDC Authorization Code grant
                 // times out, requiring another attempt at authentication.
-                "state_timeout_in_seconds": 600
+                "state_timeout_in_seconds": 600,
 
                 // The name of the OIDC claim which provides the mapping of an
                 // OIDC user to an iRODS user account
-                "irods_user_claim": "irods_username"
+                "irods_user_claim": "irods_username",
+
+                // The path to the TLS certificates directory.
+                // Used for HTTPS connections.
+                "tls_certificates_directory": "/path/to/certs"
             }
         },
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/process_stash.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/session.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/transport.cpp"
 )
 
 target_link_libraries(

--- a/core/include/irods/private/http_api/transport.hpp
+++ b/core/include/irods/private/http_api/transport.hpp
@@ -1,0 +1,79 @@
+#ifndef IRODS_HTTP_API_TRANSPORT_HPP
+#define IRODS_HTTP_API_TRANSPORT_HPP
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/ssl.hpp>
+#include <boost/beast/core/tcp_stream.hpp>
+#include <boost/beast/http/string_body.hpp>
+#include <boost/beast/http/read.hpp>
+#include <boost/beast/http/write.hpp>
+#include <boost/beast/ssl.hpp>
+#include <boost/url/parse.hpp>
+
+#include <string_view>
+#include <memory>
+
+namespace irods::http
+{
+	class transport
+	{
+	  public:
+		explicit transport(boost::asio::io_context& _ctx);
+		virtual ~transport() = default;
+
+		auto connect(std::string_view _host, std::string_view _port) -> void;
+		auto is_connected() -> bool;
+		auto communicate(boost::beast::http::request<boost::beast::http::string_body>& _request)
+			-> boost::beast::http::response<boost::beast::http::string_body>;
+
+	  protected:
+		virtual auto resolve(std::string_view _host, std::string_view _port)
+			-> boost::asio::ip::tcp::resolver::results_type;
+
+	  private:
+		virtual auto do_connect(boost::asio::ip::tcp::resolver::results_type& _resolved_host) -> void = 0;
+		virtual auto do_write(boost::beast::http::request<boost::beast::http::string_body>& _request) -> void = 0;
+		virtual auto do_read() -> boost::beast::http::response<boost::beast::http::string_body> = 0;
+
+		boost::asio::io_context& _io_ctx;
+		bool _did_connect;
+	}; // class transport
+
+	class tls_transport : public transport
+	{
+	  public:
+		tls_transport(boost::asio::io_context& _ctx, boost::asio::ssl::context& _secure_ctx);
+		virtual ~tls_transport();
+
+	  private:
+		auto resolve(std::string_view _host, std::string_view _port)
+			-> boost::asio::ip::tcp::resolver::results_type override;
+		auto do_connect(boost::asio::ip::tcp::resolver::results_type& _resolved_host) -> void override;
+		auto do_write(boost::beast::http::request<boost::beast::http::string_body>& _request) -> void override;
+		auto do_read() -> boost::beast::http::response<boost::beast::http::string_body> override;
+		auto disconnect() -> void;
+		auto set_sni_hostname(std::string_view _host) -> void;
+
+		boost::beast::ssl_stream<boost::beast::tcp_stream> _stream;
+	}; // class tls_transport
+
+	class plain_transport : public transport
+	{
+	  public:
+		explicit plain_transport(boost::asio::io_context& _ctx);
+		virtual ~plain_transport();
+
+	  private:
+		auto do_connect(boost::asio::ip::tcp::resolver::results_type& _resolved_host) -> void override;
+		auto do_write(boost::beast::http::request<boost::beast::http::string_body>& _request) -> void override;
+		auto do_read() -> boost::beast::http::response<boost::beast::http::string_body> override;
+		auto disconnect() -> void;
+
+		boost::beast::tcp_stream _stream;
+	}; // class plain_transport
+
+	auto transport_factory(const boost::urls::scheme& _scheme, boost::asio::io_context& _ctx)
+		-> std::unique_ptr<transport>;
+} //namespace irods::http
+#endif

--- a/core/src/transport.cpp
+++ b/core/src/transport.cpp
@@ -1,0 +1,157 @@
+#include "irods/private/http_api/transport.hpp"
+
+#include "irods/private/http_api/globals.hpp"
+
+#include <stdexcept>
+
+namespace irods::http
+{
+	transport::transport(boost::asio::io_context& _ctx)
+		: _io_ctx{_ctx}
+	{
+	}
+
+	auto transport::connect(std::string_view _host, std::string_view _port) -> void
+	{
+		auto res{resolve(_host, _port)};
+		do_connect(res);
+		_did_connect = true;
+	}
+
+	auto transport::is_connected() -> bool
+	{
+		return _did_connect;
+	}
+
+	auto transport::communicate(boost::beast::http::request<boost::beast::http::string_body>& _request)
+		-> boost::beast::http::response<boost::beast::http::string_body>
+	{
+		do_write(_request);
+		return do_read();
+	}
+
+	auto transport::resolve(std::string_view _host, std::string_view _port)
+		-> boost::asio::ip::tcp::resolver::results_type
+	{
+		boost::asio::ip::tcp::resolver tcp_res{_io_ctx};
+		return tcp_res.resolve(_host, _port);
+	}
+
+	tls_transport::tls_transport(boost::asio::io_context& _ctx, boost::asio::ssl::context& _secure_ctx)
+		: transport{_ctx}
+		, _stream{_ctx, _secure_ctx}
+	{
+	}
+
+	tls_transport::~tls_transport()
+	{
+		if (is_connected()) {
+			disconnect();
+		}
+	}
+
+	auto tls_transport::resolve(std::string_view _host, std::string_view _port)
+		-> boost::asio::ip::tcp::resolver::results_type
+	{
+		set_sni_hostname(_host);
+		return transport::resolve(_host, _port);
+	}
+
+	auto tls_transport::do_connect(boost::asio::ip::tcp::resolver::results_type& _resolved_host) -> void
+	{
+		boost::beast::get_lowest_layer(_stream).connect(_resolved_host);
+		_stream.handshake(boost::asio::ssl::stream_base::client);
+	}
+
+	auto tls_transport::do_write(boost::beast::http::request<boost::beast::http::string_body>& _request) -> void
+	{
+		boost::beast::http::write(_stream, _request);
+	}
+
+	auto tls_transport::do_read() -> boost::beast::http::response<boost::beast::http::string_body>
+	{
+		boost::beast::flat_buffer buffer;
+		boost::beast::http::response<boost::beast::http::string_body> res;
+		boost::beast::http::read(_stream, buffer, res);
+
+		return res;
+	}
+
+	auto tls_transport::disconnect() -> void
+	{
+		boost::beast::error_code ec;
+		_stream.shutdown(ec);
+	}
+
+	auto tls_transport::set_sni_hostname(std::string_view _host) -> void
+	{
+		// Set SNI Hostname (many hosts need this to handshake successfully)
+		if (!SSL_set_tlsext_host_name(_stream.native_handle(), _host.data())) {
+			boost::beast::error_code ec{static_cast<int>(::ERR_get_error()), boost::asio::error::get_ssl_category()};
+			throw boost::beast::system_error{ec};
+		}
+	}
+
+	plain_transport::plain_transport(boost::asio::io_context& _ctx)
+		: transport{_ctx}
+		, _stream{_ctx}
+	{
+	}
+
+	plain_transport::~plain_transport()
+	{
+		if (is_connected()) {
+			disconnect();
+		}
+	}
+
+	auto plain_transport::do_connect(boost::asio::ip::tcp::resolver::results_type& _resolved_host) -> void
+	{
+		_stream.connect(_resolved_host);
+	}
+
+	auto plain_transport::do_write(boost::beast::http::request<boost::beast::http::string_body>& _request) -> void
+	{
+		boost::beast::http::write(_stream, _request);
+	}
+
+	auto plain_transport::do_read() -> boost::beast::http::response<boost::beast::http::string_body>
+	{
+		boost::beast::flat_buffer buffer;
+		boost::beast::http::response<boost::beast::http::string_body> res;
+		boost::beast::http::read(_stream, buffer, res);
+
+		return res;
+	}
+
+	auto plain_transport::disconnect() -> void
+	{
+		boost::beast::error_code ec;
+		_stream.socket().shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
+	}
+
+	auto make_secure_context() -> boost::asio::ssl::context
+	{
+		boost::asio::ssl::context ctx{boost::asio::ssl::context::tlsv12_client};
+		const auto config{irods::http::globals::oidc_configuration()};
+
+		const std::string& cert_path{config.at("tls_certificates_directory").get_ref<const std::string&>()};
+		ctx.add_verify_path(cert_path);
+		ctx.set_verify_mode(boost::asio::ssl::verify_peer);
+
+		return ctx;
+	}
+
+	auto transport_factory(const boost::urls::scheme& _scheme, boost::asio::io_context& _ctx)
+		-> std::unique_ptr<transport>
+	{
+		if (_scheme == boost::urls::scheme::http) {
+			return std::make_unique<plain_transport>(_ctx);
+		}
+		if (_scheme == boost::urls::scheme::https) {
+			auto secure_context{make_secure_context()};
+			return std::make_unique<tls_transport>(_ctx, secure_context);
+		}
+		throw std::invalid_argument{"Scheme is not a supported."};
+	}
+} //namespace irods::http


### PR DESCRIPTION
Use TLS/SSL for OIDC communication when given an `https://...` link.