### PR TITLE
[#155,#235,#108] Make HTTP API a Protected Resource, Add support of Confidential Client, User Mapping

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,12 +30,16 @@ Reauthentication can be performed at anytime and will result in a brand new toke
 
 ### Scheme: OpenID Connect (OIDC)
 
-For authenticating with OpenID Connect, there are two methods:
+For authenticating with OpenID Connect, there are three methods, two of which are run as clients:
 
-- Resource Owner Password Credentials Grant
-- Authorization Code Grant
+- Client-Based
+  - [Resource Owner Password Credentials Grant](#resource-owner-password-credentials-grant)
+  - [Authorization Code Grant](#authorization-code-grant)
+- [Protected Resource](#irods-as-an-oauth-protected-resource)
 
 #### Resource Owner Password Credentials Grant
+
+To run this client-based scheme, you must set `mode` in the `openid_connect` stanza to `client`.
 
 The core advantage of this grant is the flexibility in how it may be applied.
 
@@ -52,6 +56,8 @@ curl -X POST -H "Authorization: iRODS $username_and_password" \
 A string representing a bearer token that can be used to execute operations as the authenticated user.
 
 #### Authorization Code Grant
+
+To run this client-based scheme, you must set `mode` in the `openid_connect` stanza to `client`.
 
 Using this grant requires a bit more work to extract the token.
 Authentication is done in the browser.
@@ -83,6 +89,20 @@ This will open a browser window that will allow you to authenticate in.
 
 ##### Response
 The bearer token should be returned and viewable in the browser window after authenticating.
+
+#### iRODS as an OAuth Protected Resource
+To run as an OAuth protected resource, set `mode` in the `openid_connect` stanza to `protected_resource`.
+
+While running in this mode, the HTTP API does not provide any grants to which you can authenticate.
+Instead, you must implement an OAuth client yourself, authenticate, and provide an access token as a
+Bearer token when querying the HTTP API endpoints.
+
+In order for the access token to be accepted, two conditions must be met:
+1. The OpenID Provider recognizes the token as valid and active.
+2. The token must be able to be mapped to a user, using either `irods_user_claim` or `user_attribute_mapping`. 
+
+If these conditions are met, then the access token will be accepted, and the action will be carried out as the mapped
+user.
 
 ## Collection Operations
 

--- a/README.md
+++ b/README.md
@@ -263,6 +263,16 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
                 // The client id given to the application by OIDC provider.
                 "client_id": "irods_http_api",
 
+                // The client secret used for accessing the introspection endpoint.
+                // Optional unless running as a protected resource.
+                "client_secret": "xxxxxxxxxxxxxxx",
+
+                // The OIDC mode the HTTP API will run as.
+                // The following values are supported:
+                // - client:              Run the HTTP API as an OIDC client
+                // - protected_resource:  Run as an OAuth Protected Resource
+                "mode": "client",
+
                 // URI pointing to the irods HTTP API auth endpoint.
                 "redirect_uri": "https://<domain>/irods-http-api/0.2.0/authenticate",
 
@@ -271,8 +281,19 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
                 "state_timeout_in_seconds": 600,
 
                 // The name of the OIDC claim which provides the mapping of an
-                // OIDC user to an iRODS user account
+                // OIDC user to an iRODS user account.
+                // "irods_user_claim" and "user_attribute_mapping" cannot be used together.
                 "irods_user_claim": "irods_username",
+
+                // The mapping of a user to the provided values. All values must
+                // be matched to map an OIDC user to an iRODS user account.
+                // "irods_user_claim" and "user_attribute_mapping" cannot be used together.
+                "user_attribute_mapping": {
+                    "irods_username": {
+                        "sub": "123-abc-456-xyz",
+                        "email": "rods_user@example.org"
+                    }
+                },
 
                 // The path to the TLS certificates directory.
                 // Used for HTTPS connections.

--- a/core/include/irods/private/http_api/common.hpp
+++ b/core/include/irods/private/http_api/common.hpp
@@ -16,6 +16,8 @@
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 
+#include <nlohmann/json.hpp>
+
 #include <chrono>
 #include <memory>
 #include <optional>
@@ -44,6 +46,7 @@ namespace irods::http
 	using request_handler_map_type = std::unordered_map<std::string_view, request_handler_type>;
 
 	using query_arguments_type = std::unordered_map<std::string, std::string>;
+	using body_arguments = std::unordered_map<std::string, std::string>;
 
 	using handler_type = void (*)(session_pointer_type, request_type&, query_arguments_type&);
 	// clang-format on
@@ -154,6 +157,17 @@ namespace irods::http
 	auto parse_url(const std::string& _url) -> url;
 
 	auto parse_url(const request_type& _req) -> url;
+
+	auto url_encode_body(const body_arguments& _args) -> std::string;
+
+	auto safe_base64_encode(std::string_view _view) -> std::string;
+
+	auto create_host_field(boost::urls::url_view _url, std::string_view _port) -> std::string;
+
+	auto create_oidc_request(boost::urls::url_view _url)
+		-> boost::beast::http::request<boost::beast::http::string_body>;
+
+	auto map_json_to_user(const nlohmann::json& _json) -> std::optional<std::string>;
 
 	auto resolve_client_identity(const request_type& _req) -> client_identity_resolution_result;
 

--- a/test/config.py
+++ b/test/config.py
@@ -1,4 +1,5 @@
 import logging
+from jsonschema import validate
 
 test_config = {
     'log_level': logging.INFO,
@@ -6,6 +7,10 @@ test_config = {
     'host': 'localhost',
     'port': 9000,
     'url_base': '/irods-http-api/0.2.0',
+
+    'openid_connect': {
+        'mode': 'client'
+    },
 
     'rodsadmin': {
         'username': 'rods',
@@ -20,5 +25,73 @@ test_config = {
     'irods_zone': 'tempZone',
     'irods_server_hostname': 'localhost',
 
-    "run_genquery2_tests": False
+    'run_genquery2_tests': False
 }
+
+schema = {
+    '$schema': 'http://json-schema.org/draft-07/schema#',
+    '$id': 'https://schemas.irods.org/irods-http-api/test/0.2.0/test-schema.json',
+    'type': 'object',
+    'properties': {
+        'host': {
+            'type': 'string'
+        },
+        'port': {
+            'type': 'number'
+        },
+        'url_base': {
+            'type': 'string'
+        },
+        'openid_connect': {
+            'type': 'object',
+            'properties': {
+                'mode': {
+                    'enum': [ 'client', 'protected_resource' ]
+                }
+            },
+            'required': [ 'mode' ]
+        },
+        'rodsadmin': {
+            '$ref': '#/definitions/login'
+        },
+        'rodsuser': {
+            '$ref': '#/definitions/login'
+        },
+        'irods_zone': {
+            'type': 'string'
+        },
+        'irods_server_hostname': {
+            'type': 'string'
+        },
+        'run_genquery2_tests': {
+            'type': 'boolean'
+        }
+    },
+    'required': [
+        'host',
+        'port',
+        'url_base',
+        'openid_connect',
+        'rodsadmin',
+        'rodsuser',
+        'irods_zone',
+        'irods_server_hostname',
+        'run_genquery2_tests'
+    ],
+    'definitions': {
+        'login': {
+            'type': 'object',
+            'properties': {
+                'username': {
+                    'type': 'string'
+                },
+                'password': {
+                    'type': 'string'
+                }
+            },
+            'required': [ 'username', 'password' ]
+        }
+    }
+}
+
+validate(instance=test_config, schema=schema)

--- a/test/test_auth_endpoint.py
+++ b/test/test_auth_endpoint.py
@@ -1,3 +1,4 @@
+from config import test_config
 import pytest
 import requests
 import base64
@@ -5,32 +6,41 @@ import re
 import logging
 import html
 
-# Pragmatic
-# Search for IRODS_HTTP_API_BASE_URL
-# and IRODS_CLIENT_VERSION
-# TOOD: Consider turning this into a fixture
-AUTH_URL = 'http://127.0.0.1:9000/irods-http-api/0.2.0/authenticate'
+skip_protected_resource = pytest.mark.skipif(
+    test_config['openid_connect']['mode'] == 'protected_resource', reason='Not supported in "protected_resource" mode.')
 
-@pytest.mark.parametrize("username, password, expected_result", [('bob', 'bob', requests.codes.ok),
-                                                                 ('', '', requests.codes.unauthorized),
+skip_client = pytest.mark.skipif(
+    test_config['openid_connect']['mode'] == 'client', reason='Not supported in "client" mode.')
+
+@pytest.fixture
+def irods_http_api_url_base():
+    return f'http://{test_config["host"]}:{test_config["port"]}{test_config["url_base"]}'
+
+@pytest.fixture
+def auth_url(irods_http_api_url_base):
+    return f'{irods_http_api_url_base}/authenticate'
+
+@pytest.mark.parametrize("username, password, expected_result", [pytest.param('bob', 'bob', requests.codes.ok, marks=skip_protected_resource),
+                                                                 pytest.param('', '', requests.codes.unauthorized, marks=skip_protected_resource),
                                                                  ('not', 'valid', requests.codes.bad_request),
-                                                                 ('a'*200, 'b'*200, requests.codes.unauthorized)])
-def test_oidc_resource_owner_password_credentials_login(username, password, expected_result):
+                                                                 pytest.param('a'*200, 'b'*200, requests.codes.unauthorized, marks=skip_protected_resource)])
+def test_oidc_resource_owner_password_credentials_login(username, password, expected_result, auth_url):
     to_be_encoded = f'{username}:{password}'
     encoded_user_pass = base64.b64encode(to_be_encoded.encode())
 
-    res = requests.post(AUTH_URL, headers={'Authorization': f'iRODS {encoded_user_pass.decode()}'})
+    res = requests.post(auth_url, headers={'Authorization': f'iRODS {encoded_user_pass.decode()}'})
 
     # Got a good code, assume we passed...
     assert res.status_code == expected_result
 
-def test_oidc_authorization_code_login():
+@skip_protected_resource
+def test_oidc_authorization_code_login(auth_url):
     # Session required for cookie
     s = requests.Session()
 
     # Go to login page
     # requests automatically redirects
-    res = s.get(AUTH_URL)
+    res = s.get(auth_url)
     assert res.status_code == requests.codes.ok
 
     data = res.text
@@ -51,13 +61,14 @@ def test_oidc_authorization_code_login():
     # Make sure we weren't redirected back the the auth page
     assert re.match('<!DOCTYPE html>', res.text) is None
 
-def test_oidc_authorization_code_non_irods_user():
+@skip_protected_resource
+def test_oidc_authorization_code_non_irods_user(auth_url):
     # Session required for cookie
     s = requests.Session()
 
     # Go to login page
     # requests automatically redirects
-    res = s.get(AUTH_URL)
+    res = s.get(auth_url)
     assert res.status_code == requests.codes.ok
 
     data = res.text
@@ -75,31 +86,33 @@ def test_oidc_authorization_code_non_irods_user():
     res = s.post(extracted_url, data={'username': 'non_irods_user', 'password': 'bad', 'credentialId': ''})
     assert res.status_code == requests.codes.bad_request
 
-
 @pytest.mark.parametrize("username, password, expected_result", [('rods', 'rods', requests.codes.ok),
                                                                  ('', '', requests.codes.unauthorized),
                                                                  ('not', 'valid', requests.codes.unauthorized),
                                                                  ('a'*200, 'b'*200, requests.codes.unauthorized)])
-def test_post_basic_login(username, password, expected_result):
-    res = requests.post(AUTH_URL, auth=(username, password))
+def test_post_basic_login(username, password, expected_result, auth_url):
+    res = requests.post(auth_url, auth=(username, password))
 
     # Got a good code, assume we passed...
     assert res.status_code == expected_result
 
+@pytest.mark.parametrize("state, code", [('placeholder', 'bad_code'),
+                                         ('', 'bad_code'),
+                                         ('placeholder', ''),
+                                         ('a'*200, 'b'*200)])
+def test_get_oidc_errors(state, code, auth_url):
+    res = requests.get(auth_url, params={'state': state, 'code': code})
 
-@pytest.mark.parametrize("state, code, expected_result", [('placeholder', 'bad_code', requests.codes.bad_request),
-                                                          ('', 'bad_code', requests.codes.bad_request),
-                                                          ('placeholder', '', requests.codes.bad_request),
-                                                          ('a'*200, 'b'*200, requests.codes.bad_request)])
-def test_get_oidc_errors(state, code, expected_result):
-    res = requests.get(AUTH_URL, params={'state': state, 'code': code})
-
-    assert res.status_code == expected_result
+    if test_config['openid_connect']['mode'] == 'client':
+        assert res.status_code == requests.codes.bad_request
+    else:
+        assert res.status_code == requests.codes.method_not_allowed
 
 @pytest.mark.parametrize("method", [requests.head,
+                                    pytest.param(requests.get, marks=skip_client),
                                     requests.put,
                                     requests.delete,
                                     requests.patch])
-def test_other_http_methods(method):
-    res = method(AUTH_URL)
+def test_other_http_methods(method, auth_url):
+    res = method(auth_url)
     assert res.status_code == requests.codes.method_not_allowed


### PR DESCRIPTION
## Summary
The primary goal of this PR is to allow the HTTP API to receive access tokens on all of the iRODS HTTP API endpoints. We do this while moving away from the currently used HTTP API tokens in OAuth related authorization. A major reason for moving towards OAuth tokens is for better integration with existing providers, as well as improved compliance to desired token properties (e.g. token expiration, revocation).

As part of this implementation, confidential clients and user mapping needed to be implemented. The implementation of confidential clients should allow for the HTTP API to contact the OpenID Provider's introspection endpoint, among other benefits. Additionally, the alternate user mapping system allows for further flexibility on how to map tokens to iRODS users.

---
### OAuth Protected Resource #155
This allows access to the HTTP API endpoints by passing an access token as a Bearer token, as is specified in the OAuth specification: https://www.rfc-editor.org/rfc/rfc6749.html#section-7.1

Taking directly from the example provided in the above link, you would just need to send the access token as bearer:
```
GET /resource/1 HTTP/1.1
     Host: example.com
     Authorization: Bearer mF_9.B5f-4.1JqM
```

By sending a valid Bearer token, you should have access to the iRODS HTTP API endpoints. It should be noted that access will only be permitted in the following conditions:

1. The access token provided is valid.
2. The token can be matched to an iRODS user.

### Confidential Client Support #235
If you define `client_secret` in your configuration, this will run the HTTP API as a confidential client. This should allow for access to protected endpoints on the provider, such as the introspection endpoint, among other benefits.

When running as a confidential client, all requests to the OpenID Provider, aside from well-known endpoint, will send a Bearer token in the Authorization header with the provided `client_id` and `client_secret`, as described in the OAuth 2.0 specification: https://www.rfc-editor.org/rfc/rfc6749.html#section-2.3.1

### User Mapping #108
Without a mapping mechanism of access tokens to iRODS users, the HTTP API would not be able to function. By specifying the iRODS user, as well as the desired mapping attributes to search for. An example of a mapping can be found below:

```json
"openid_connect": {
  "user_attribute_mapping": {
    "rodsBob": {
      "email": "bob@bobtopia.example",
      "sub": "a.very.real.sub",
      "phone_number": "56709"
    },
    "rodsAlice": {
      "email": "al-1s@wonderland.example",
      "sub": "a.different.sub"
    }
  }
}
```

It should be noted that each iRODS user does not require the same number of attributes. Each of the given attributes must match completely in order for the token to be mapped to a user.

When running as a Protected Resource, these mappings will be matched with the response given from the OpenID Provider's introspection endpoint. An example of what may be in an introspection endpoint's response is as follows:

```json
 {
      "active": true,
      "client_id": "l238j323ds-23ij4",
      "username": "jdoe",
      "scope": "read write dolphin",
      "sub": "Z5O3upPC88QrAjx00dis",
      "aud": "https://protected.example.net/resource",
      "iss": "https://server.example.com/",
      "exp": 1419356238,
      "iat": 1419350238,
      "extension_field": "twenty-seven"
 }
```

The previous example was taken from the OAuth 2.0 Token Introspection specification, which can be found at the following link: https://www.rfc-editor.org/rfc/rfc7662.html#section-2.2

Otherwise, they will match against the OpenID Provider's ID Token, given in response to a token endpoint request. An example of what may be in an ID Token is as follows:

```json
{
   "iss": "https://server.example.com",
   "sub": "24400320",
   "aud": "s6BhdRkqt3",
   "nonce": "n-0S6_WzA2Mj",
   "exp": 1311281970,
   "iat": 1311280970,
   "auth_time": 1311280969,
   "acr": "urn:mace:incommon:iap:silver"
}
```

The previous example was taken from the OpenID Connect Core 1.0 specification, which can be found in the following link: https://openid.net/specs/openid-connect-core-1_0.html#IDToken