### PR TITLE
[irods/irods_7220] do not redefine `log`

### DIFF
--- a/endpoints/collections/src/main.cpp
+++ b/endpoints/collections/src/main.cpp
@@ -36,8 +36,8 @@ namespace beast = boost::beast;     // from <boost/beast.hpp>
 namespace http  = beast::http;      // from <boost/beast/http.hpp>
 namespace net   = boost::asio;      // from <boost/asio.hpp>
 
-namespace fs  = irods::experimental::filesystem;
-namespace log = irods::http::log;
+namespace fs      = irods::experimental::filesystem;
+namespace logging = irods::http::log;
 
 using json = nlohmann::json;
 // clang-format on
@@ -119,7 +119,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -129,7 +129,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [lpath] parameter.", fn);
+					logging::error("{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -172,18 +172,18 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}, {"entries", entries}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -207,7 +207,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -217,7 +217,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [lpath] parameter.", fn);
+					logging::error("{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -266,18 +266,18 @@ namespace
 						.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -301,7 +301,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -311,7 +311,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [lpath] parameter.", fn);
+					logging::error("{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -361,7 +361,7 @@ namespace
 				// clang-format on
 			}
 			catch (const fs::filesystem_error& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -372,7 +372,7 @@ namespace
 				// clang-format on
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -383,7 +383,7 @@ namespace
 				// clang-format on
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -407,7 +407,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -417,7 +417,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [lpath] parameter.", fn);
+					logging::error("{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -448,18 +448,18 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -483,7 +483,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -493,7 +493,7 @@ namespace
 			try {
 				const auto old_lpath_iter = _args.find("old-lpath");
 				if (old_lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [old-lpath] parameter.", fn);
+					logging::error("{}: Missing [old-lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -508,7 +508,7 @@ namespace
 
 				const auto new_lpath_iter = _args.find("new-lpath");
 				if (new_lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [new-lpath] parameter.", fn);
+					logging::error("{}: Missing [new-lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -518,7 +518,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
@@ -526,18 +526,18 @@ namespace
 				}
 			}
 			catch (const fs::filesystem_error& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -561,7 +561,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -571,7 +571,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [lpath] parameter.", fn);
+					logging::error("{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -586,19 +586,19 @@ namespace
 
 				const auto entity_name_iter = _args.find("entity-name");
 				if (entity_name_iter == std::end(_args)) {
-					log::error("{}: Missing [entity-name] parameter.", fn);
+					logging::error("{}: Missing [entity-name] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
 				const auto perm_iter = _args.find("permission");
 				if (perm_iter == std::end(_args)) {
-					log::error("{}: Missing [permission] parameter.", fn);
+					logging::error("{}: Missing [permission] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
 				const auto perm_enum = irods::to_permission_enum(perm_iter->second);
 				if (!perm_enum) {
-					log::error("{}: Invalid value for [permission] parameter.", fn);
+					logging::error("{}: Invalid value for [permission] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -615,25 +615,25 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 			}
 			catch (const fs::filesystem_error& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -657,7 +657,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -667,13 +667,13 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [lpath] parameter.", fn);
+					logging::error("{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
 				const auto enable_iter = _args.find("enable");
 				if (enable_iter == std::end(_args)) {
-					log::error("{}: Missing [enable] parameter.", fn);
+					logging::error("{}: Missing [enable] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -697,7 +697,7 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -708,7 +708,7 @@ namespace
 				// clang-format off
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -719,7 +719,7 @@ namespace
 				// clang-format off
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -752,7 +752,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -762,7 +762,7 @@ namespace
 				try {
 					const auto lpath_iter = _args.find("lpath");
 					if (lpath_iter == std::end(_args)) {
-						log::error("{}: Missing [lpath] parameter.", fn);
+						logging::error("{}: Missing [lpath] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -775,7 +775,7 @@ namespace
 							options["seconds_since_epoch"] = std::stoi(opt_iter->second);
 						}
 						catch (const std::exception& e) {
-							log::error(
+							logging::error(
 								"{}: Could not convert seconds-since-epoch [{}] into an integer.",
 								fn,
 								opt_iter->second);
@@ -806,7 +806,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -817,7 +817,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/endpoints/query/src/main.cpp
+++ b/endpoints/query/src/main.cpp
@@ -35,7 +35,7 @@ namespace beast = boost::beast;     // from <boost/beast.hpp>
 namespace http  = beast::http;      // from <boost/beast/http.hpp>
 namespace net   = boost::asio;      // from <boost/asio.hpp>
 
-namespace log = irods::http::log;
+namespace logging = irods::http::log;
 
 using json = nlohmann::json;
 // clang-format on
@@ -103,13 +103,13 @@ namespace
 		}
 
 		const auto client_info = result.client_info;
-		log::info("{}: client_info.username = [{}]", __func__, client_info.username);
+		logging::info("{}: client_info.username = [{}]", __func__, client_info.username);
 
 		irods::http::globals::background_task(
 			[fn = __func__, _sess_ptr, req = std::move(_req), args = std::move(_args), client_info]() mutable {
 				auto query_iter = args.find("query");
 				if (query_iter == std::end(args)) {
-					log::error("{}: Missing [query] parameter.", fn);
+					logging::error("{}: Missing [query] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 				}
 
@@ -117,7 +117,7 @@ namespace
 				const auto parser_iter = args.find("parser");
 				if (parser_iter != std::end(args)) {
 					if (parser_iter->second != "genquery1" && parser_iter->second != "genquery2") {
-						log::error("{}: Invalid argument for [parser] parameter.", fn);
+						logging::error("{}: Invalid argument for [parser] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -194,7 +194,7 @@ namespace
 								offset = std::stoi(iter->second);
 							}
 							catch (const std::exception& e) {
-								log::error("{}: Could not convert [offset] parameter value into an integer. ", fn);
+								logging::error("{}: Could not convert [offset] parameter value into an integer. ", fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -211,7 +211,7 @@ namespace
 								count = std::stoi(iter->second);
 							}
 							catch (const std::exception& e) {
-								log::error("{}: Could not convert [count] parameter value into an integer.", fn);
+								logging::error("{}: Could not convert [count] parameter value into an integer.", fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -226,7 +226,8 @@ namespace
 								boost::algorithm::to_upper(query_iter->second);
 							}
 							else if (iter->second != "1") {
-								log::error("{}: Invalid value for [case-sensitive] parameter. Expected a 1 or 0.", fn);
+								logging::error(
+									"{}: Invalid value for [case-sensitive] parameter. Expected a 1 or 0.", fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -236,7 +237,7 @@ namespace
 								options |= NO_DISTINCT;
 							}
 							else if (iter->second != "1") {
-								log::error("{}: Invalid value for [distinct] parameter. Expected a 1 or 0.", fn);
+								logging::error("{}: Invalid value for [distinct] parameter. Expected a 1 or 0.", fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -260,7 +261,7 @@ namespace
 					}
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -271,7 +272,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -289,11 +290,11 @@ namespace
 		}
 
 		const auto client_info = result.client_info;
-		log::info("{}: client_info.username = [{}]", __func__, client_info.username);
+		logging::info("{}: client_info.username = [{}]", __func__, client_info.username);
 
 		const auto name_iter = _args.find("name");
 		if (name_iter == std::end(_args)) {
-			log::error("{}: Missing [name] parameter.", __func__);
+			logging::error("{}: Missing [name] parameter.", __func__);
 			return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 		}
 
@@ -303,7 +304,7 @@ namespace
 				offset = std::stoi(iter->second);
 			}
 			catch (const std::exception& e) {
-				log::error("{}: Could not convert [offset] parameter value into an integer. ", __func__);
+				logging::error("{}: Could not convert [offset] parameter value into an integer. ", __func__);
 				return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 			}
 		}
@@ -319,7 +320,7 @@ namespace
 				count = std::stoi(iter->second);
 			}
 			catch (const std::exception& e) {
-				log::error("{}: Could not convert [count] parameter value into an integer. ", __func__);
+				logging::error("{}: Could not convert [count] parameter value into an integer. ", __func__);
 				return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 			}
 		}
@@ -398,13 +399,13 @@ namespace
 				     rows}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -418,7 +419,7 @@ namespace
 	{
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 	} // op_list_genquery_columns
 
@@ -426,7 +427,7 @@ namespace
 	{
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 	} // op_list_specific_queries
 
@@ -434,7 +435,7 @@ namespace
 	{
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 	} // op_add_specific_query
 
@@ -442,7 +443,7 @@ namespace
 	{
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 	} // op_remove_specific_query
 } // anonymous namespace

--- a/endpoints/resources/src/main.cpp
+++ b/endpoints/resources/src/main.cpp
@@ -28,8 +28,8 @@ namespace beast = boost::beast;     // from <boost/beast.hpp>
 namespace http  = beast::http;      // from <boost/beast/http.hpp>
 namespace net   = boost::asio;      // from <boost/asio.hpp>
 
-namespace adm = irods::experimental::administration;
-namespace log = irods::http::log;
+namespace adm     = irods::experimental::administration;
+namespace logging = irods::http::log;
 
 using json = nlohmann::json;
 // clang-format on
@@ -103,7 +103,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -113,13 +113,13 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
 					const auto type_iter = _args.find("type");
 					if (type_iter == std::end(_args)) {
-						log::error("{}: Missing [type] parameter.", fn);
+						logging::error("{}: Missing [type] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -152,13 +152,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -179,7 +179,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -189,7 +189,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -203,13 +203,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -230,7 +230,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -240,7 +240,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -250,7 +250,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -261,7 +261,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_modify
@@ -277,7 +277,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -287,13 +287,13 @@ namespace
 				try {
 					const auto parent_name_iter = _args.find("parent-name");
 					if (parent_name_iter == std::end(_args)) {
-						log::error("{}: Missing [parent-name] parameter.", fn);
+						logging::error("{}: Missing [parent-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
 					const auto child_name_iter = _args.find("child-name");
 					if (child_name_iter == std::end(_args)) {
-						log::error("{}: Missing [child-name] parameter.", fn);
+						logging::error("{}: Missing [child-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -315,13 +315,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -342,7 +342,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -352,13 +352,13 @@ namespace
 				try {
 					const auto parent_name_iter = _args.find("parent-name");
 					if (parent_name_iter == std::end(_args)) {
-						log::error("{}: Missing [parent-name] parameter.", fn);
+						logging::error("{}: Missing [parent-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
 					const auto child_name_iter = _args.find("child-name");
 					if (child_name_iter == std::end(_args)) {
-						log::error("{}: Missing [child-name] parameter.", fn);
+						logging::error("{}: Missing [child-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -372,13 +372,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -399,7 +399,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -409,7 +409,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -423,13 +423,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -453,7 +453,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -463,7 +463,7 @@ namespace
 			try {
 				const auto name_iter = _args.find("name");
 				if (name_iter == std::end(_args)) {
-					log::error("{}: Missing [name] parameter.", fn);
+					logging::error("{}: Missing [name] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 				}
 
@@ -541,13 +541,13 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}, {"exists", exists}, {"info", info}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/endpoints/rules/src/main.cpp
+++ b/endpoints/rules/src/main.cpp
@@ -37,7 +37,7 @@ namespace beast = boost::beast;     // from <boost/beast.hpp>
 namespace http  = beast::http;      // from <boost/beast/http.hpp>
 namespace net   = boost::asio;      // from <boost/asio.hpp>
 
-namespace log = irods::http::log;
+namespace logging = irods::http::log;
 
 using json = nlohmann::json;
 // clang-format on
@@ -104,7 +104,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -114,7 +114,7 @@ namespace
 			try {
 				const auto rule_text_iter = _args.find("rule-text");
 				if (rule_text_iter == std::end(_args)) {
-					log::error("{}: Missing [rule-text] parameter.", fn);
+					logging::error("{}: Missing [rule-text] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -159,25 +159,28 @@ namespace
 						if (auto* exec_out = static_cast<ExecCmdOut*>(msp->inOutStruct); exec_out) {
 							if (exec_out->stdoutBuf.buf) {
 								stdout_output = static_cast<const char*>(exec_out->stdoutBuf.buf);
-								log::debug("{}: stdout_output = [{}]", fn, stdout_output.get_ref<const std::string&>());
+								logging::debug(
+									"{}: stdout_output = [{}]", fn, stdout_output.get_ref<const std::string&>());
 							}
 
 							if (exec_out->stderrBuf.buf) {
 								stderr_output = static_cast<const char*>(exec_out->stderrBuf.buf);
-								log::debug("{}: stderr_output = [{}]", fn, stderr_output.get_ref<const std::string&>());
+								logging::debug(
+									"{}: stderr_output = [{}]", fn, stderr_output.get_ref<const std::string&>());
 							}
 						}
 					}
 
 					if (auto* msp = getMsParamByLabel(out_param_array, "ruleExecOut"); msp) {
-						log::debug("{}: ruleExecOut = [{}]", fn, static_cast<const char*>(msp->inOutStruct));
+						logging::debug("{}: ruleExecOut = [{}]", fn, static_cast<const char*>(msp->inOutStruct));
 					}
 				}
 
 				// Log messages stored in the RcComm::rError object.
 				if (auto* rerr_info = static_cast<RcComm*>(conn)->rError; rerr_info) {
 					for (auto&& err : std::span(rerr_info->errMsg, rerr_info->len)) {
-						log::info("{}: RcComm::rError info = [status=[{}], message=[{}]]", fn, err->status, err->msg);
+						logging::info(
+							"{}: RcComm::rError info = [status=[{}], message=[{}]]", fn, err->status, err->msg);
 					}
 
 					freeRError(rerr_info);
@@ -189,13 +192,13 @@ namespace
 						.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -216,7 +219,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -226,7 +229,7 @@ namespace
 				try {
 					const auto rule_id_iter = _args.find("rule-id");
 					if (rule_id_iter == std::end(_args)) {
-						log::error("{}: Missing [rule-id] parameter.", fn);
+						logging::error("{}: Missing [rule-id] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -243,13 +246,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -273,7 +276,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -327,13 +330,13 @@ namespace
 						.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/endpoints/shared/src/shared_api_operations.cpp
+++ b/endpoints/shared/src/shared_api_operations.cpp
@@ -25,8 +25,8 @@ namespace beast = boost::beast;     // from <boost/beast.hpp>
 namespace http  = beast::http;      // from <boost/beast/http.hpp>
 namespace net   = boost::asio;      // from <boost/asio.hpp>
 
-namespace fs  = irods::experimental::filesystem;
-namespace log = irods::http::log;
+namespace fs      = irods::experimental::filesystem;
+namespace logging = irods::http::log;
 
 using json = nlohmann::json;
 // clang-format on
@@ -44,7 +44,7 @@ namespace irods::http::shared_api_operations
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _entity_type, _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				::http::response<::http::string_body> res{::http::status::ok, _req.version()};
 				res.set(::http::field::server, irods::http::version::server_name);
@@ -54,13 +54,13 @@ namespace irods::http::shared_api_operations
 				try {
 					const auto lpath_iter = _args.find("lpath");
 					if (lpath_iter == std::end(_args)) {
-						log::error("{}: Missing [lpath] parameter.", fn);
+						logging::error("{}: Missing [lpath] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
 					const auto operations_iter = _args.find("operations");
 					if (operations_iter == std::end(_args)) {
-						log::error("{}: Missing [operations] parameter.", fn);
+						logging::error("{}: Missing [operations] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
@@ -120,7 +120,7 @@ namespace irods::http::shared_api_operations
 					res.body() = response.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -131,7 +131,7 @@ namespace irods::http::shared_api_operations
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(::http::status::internal_server_error);
 				}
 
@@ -152,7 +152,7 @@ namespace irods::http::shared_api_operations
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _entity_type, _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				::http::response<::http::string_body> res{::http::status::ok, _req.version()};
 				res.set(::http::field::server, irods::http::version::server_name);
@@ -162,7 +162,7 @@ namespace irods::http::shared_api_operations
 				try {
 					const auto operations_iter = _args.find("operations");
 					if (operations_iter == std::end(_args)) {
-						log::error("{}: Missing [operations] parameter.", fn);
+						logging::error("{}: Missing [operations] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
@@ -192,13 +192,13 @@ namespace irods::http::shared_api_operations
 							break;
 
 						default:
-							log::error("{}: Invalid entity type for atomic metadata operations.", fn);
+							logging::error("{}: Invalid entity type for atomic metadata operations.", fn);
 							return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
 					const auto entity_name_iter = _args.find(std::string{ename_param});
 					if (entity_name_iter == std::end(_args)) {
-						log::error("{}: Missing [{}] parameter.", fn, ename_param);
+						logging::error("{}: Missing [{}] parameter.", fn, ename_param);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
@@ -234,7 +234,7 @@ namespace irods::http::shared_api_operations
 					res.body() = response.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -245,7 +245,7 @@ namespace irods::http::shared_api_operations
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(::http::status::internal_server_error);
 				}
 

--- a/endpoints/tickets/src/main.cpp
+++ b/endpoints/tickets/src/main.cpp
@@ -27,8 +27,8 @@ namespace beast = boost::beast;     // from <boost/beast.hpp>
 namespace http  = beast::http;      // from <boost/beast/http.hpp>
 namespace net   = boost::asio;      // from <boost/asio.hpp>
 
-namespace adm = irods::experimental::administration;
-namespace log = irods::http::log;
+namespace adm     = irods::experimental::administration;
+namespace logging = irods::http::log;
 
 using json = nlohmann::json;
 // clang-format on
@@ -94,7 +94,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -104,7 +104,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -114,7 +114,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -125,7 +125,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_list
@@ -141,7 +141,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -151,7 +151,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -161,7 +161,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -172,7 +172,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_stat
@@ -191,7 +191,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			log::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -201,7 +201,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					log::error("{}: Missing [lpath] parameter.", fn);
+					logging::error("{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -212,7 +212,7 @@ namespace
 						ticket_type = adm::ticket::ticket_type::write;
 					}
 					else if (type_iter->second != "read") {
-						log::error("{}: Invalid value for [type] parameter.", fn);
+						logging::error("{}: Invalid value for [type] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 				}
@@ -253,7 +253,7 @@ namespace
 				constraint_iter = _args.find("seconds-until-expiration");
 				if (constraint_iter != std::end(_args)) {
 					// TODO Not yet supported by the ticket administration library.
-					log::warn("{}: Ignoring [seconds-until-expiration]. Not implemented at this time.", fn);
+					logging::warn("{}: Ignoring [seconds-until-expiration]. Not implemented at this time.", fn);
 				}
 
 				constraint_iter = _args.find("users");
@@ -292,13 +292,13 @@ namespace
 				     ticket}}.dump();
 			}
 			catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -319,7 +319,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -329,7 +329,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -343,13 +343,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/endpoints/users_groups/src/main.cpp
+++ b/endpoints/users_groups/src/main.cpp
@@ -29,8 +29,8 @@ namespace beast = boost::beast;     // from <boost/beast.hpp>
 namespace http  = beast::http;      // from <boost/beast/http.hpp>
 namespace net   = boost::asio;      // from <boost/asio.hpp>
 
-namespace adm = irods::experimental::administration;
-namespace log = irods::http::log;
+namespace adm     = irods::experimental::administration;
+namespace logging = irods::http::log;
 
 using json = nlohmann::json;
 // clang-format on
@@ -122,7 +122,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -132,13 +132,13 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						log::error("{}: Missing [zone] parameter.", fn);
+						logging::error("{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -152,7 +152,7 @@ namespace
 							user_type = adm::user_type::groupadmin;
 						}
 						else {
-							log::error("{}: Invalid value for [user-type] parameter.", fn);
+							logging::error("{}: Invalid value for [user-type] parameter.", fn);
 							return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 						}
 					}
@@ -175,7 +175,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -186,7 +186,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -207,7 +207,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -217,13 +217,13 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						log::error("{}: Missing [zone] parameter.", fn);
+						logging::error("{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -239,7 +239,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -250,7 +250,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -271,7 +271,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -281,19 +281,19 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						log::error("{}: Missing [zone] parameter.", fn);
+						logging::error("{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto new_password_iter = _args.find("new-password");
 					if (new_password_iter == std::end(_args)) {
-						log::error("{}: Missing [new-password] parameter.", fn);
+						logging::error("{}: Missing [new-password] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -309,7 +309,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -320,7 +320,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -341,7 +341,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -351,19 +351,19 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						log::error("{}: Missing [zone] parameter.", fn);
+						logging::error("{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto new_user_type_iter = _args.find("new-user-type");
 					if (new_user_type_iter == std::end(_args)) {
-						log::error("{}: Missing [new-user-type] parameter.", fn);
+						logging::error("{}: Missing [new-user-type] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -381,7 +381,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -392,7 +392,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -413,7 +413,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -423,7 +423,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -433,7 +433,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -444,7 +444,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_add_user_auth
@@ -460,7 +460,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -470,7 +470,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -480,7 +480,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -491,7 +491,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_remove_user_auth
@@ -507,7 +507,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -517,7 +517,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -533,7 +533,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -544,7 +544,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -565,7 +565,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -575,7 +575,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -591,7 +591,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -602,7 +602,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -623,7 +623,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -633,19 +633,19 @@ namespace
 				try {
 					const auto user_iter = _args.find("user");
 					if (user_iter == std::end(_args)) {
-						log::error("{}: Missing [user] parameter.", fn);
+						logging::error("{}: Missing [user] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						log::error("{}: Missing [zone] parameter.", fn);
+						logging::error("{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto group_iter = _args.find("group");
 					if (group_iter == std::end(_args)) {
-						log::error("{}: Missing [group] parameter.", fn);
+						logging::error("{}: Missing [group] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -660,13 +660,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -687,7 +687,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -697,19 +697,19 @@ namespace
 				try {
 					const auto user_iter = _args.find("user");
 					if (user_iter == std::end(_args)) {
-						log::error("{}: Missing [user] parameter.", fn);
+						logging::error("{}: Missing [user] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						log::error("{}: Missing [zone] parameter.", fn);
+						logging::error("{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto group_iter = _args.find("group");
 					if (group_iter == std::end(_args)) {
-						log::error("{}: Missing [group] parameter.", fn);
+						logging::error("{}: Missing [group] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -724,13 +724,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -751,7 +751,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -772,13 +772,13 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"users", v}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -799,7 +799,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -820,13 +820,13 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"groups", v}}.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -847,7 +847,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            log::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -857,7 +857,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				log::error("{}: {}", fn, e.client_display_what());
+				logging::error("{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -867,7 +867,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				log::error("{}: {}", fn, e.what());
+				logging::error("{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -878,7 +878,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		log::error("{}: Operation not implemented.", __func__);
+		logging::error("{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_members
@@ -894,7 +894,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -904,19 +904,19 @@ namespace
 				try {
 					const auto group_iter = _args.find("group");
 					if (group_iter == std::end(_args)) {
-						log::error("{}: Missing [group] parameter.", fn);
+						logging::error("{}: Missing [group] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto user_iter = _args.find("user");
 					if (user_iter == std::end(_args)) {
-						log::error("{}: Missing [user] parameter.", fn);
+						logging::error("{}: Missing [user] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						log::error("{}: Missing [zone] parameter.", fn);
+						logging::error("{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -932,13 +932,13 @@ namespace
 							.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -959,7 +959,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				log::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -969,7 +969,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						log::error("{}: Missing [name] parameter.", fn);
+						logging::error("{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -1021,13 +1021,13 @@ namespace
 					res.body() = info.dump();
 				}
 				catch (const irods::exception& e) {
-					log::error("{}: {}", fn, e.client_display_what());
+					logging::error("{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					log::error("{}: {}", fn, e.what());
+					logging::error("{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 


### PR DESCRIPTION
In service of irods/irods#7220

In libstdc++, `log` is defined as a math function, so `namespace log = irods:http:log` causes errors when building.

This PR changes all instances of `namespace log` to `namespace logging`.

