### PR TITLE
[#290] Remove API documentation for disabled zone operation

### DIFF
--- a/API.md
+++ b/API.md
@@ -2332,36 +2332,6 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 
 If there was an error, expect an HTTP status code in either the 4XX or 5XX range.
 
-### set_zone_collection_permission
-
-Add or remove user permissions on a zone collection.
-
-#### Request
-
-```bash
-curl http://localhost:<port>/irods-http-api/<version>/zones \
-    -H 'Authorization: Bearer <token>' \
-    --data-urlencode 'op=set_zone_collection_permission' \
-    --data-urlencode 'name=<string>' \ # The name of the remote zone to modify.
-    --data-urlencode 'user=<string>' \ # The user the permission will apply to.
-    --data-urlencode 'permission=<string>' # The permission to set for the user. null or read.
-```
-
-#### Response
-
-If an HTTP status code of 200 is returned, the body of the response will contain JSON. Its structure is shown below.
-
-```js
-{
-    "irods_response": {
-        "status_code": 0
-        "status_message": "string" // Optional
-    }
-}
-```
-
-If there was an error, expect an HTTP status code in either the 4XX or 5XX range.
-
 ### report
 
 Returns information about the iRODS zone.


### PR DESCRIPTION
The zone operation in question is disabled until we fully understand the iRODS API. Once we have a grasp on the API, we can revert this commit.