### PR TITLE
[#272] Update dependencies to iRODS 4.3.2 for GenQuery2

### DIFF
--- a/API.md
+++ b/API.md
@@ -1282,7 +1282,6 @@ If an HTTP status code of 200 is returned, the body of the response will contain
 {
     "api_version": "string",
     "build": "string",
-    "genquery2_enabled": false,
     "irods_zone": "string",
     "max_number_of_parallel_write_streams": 0,
     "max_number_of_rows_per_catalog_query": 0,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ cmake_minimum_required(VERSION 3.18.0 FATAL_ERROR)
 # Build Configuration
 #
 
-find_package(IRODS REQUIRED)
+set(IRODS_MINIMUM_VERSION "4.3.2")
+find_package(IRODS "${IRODS_MINIMUM_VERSION}" REQUIRED)
 
 include(RequireOutOfSourceBuild)
 
@@ -64,11 +65,11 @@ if (IRODS_ENABLE_ADDRESS_SANITIZER)
   # Make sure the correct llvm-symbolizer binary is available to Address Sanitizer. This binary
   # allows debug symbols to be reported appropriately. There are two ways to do this:
   #
-  #     export PATH=/opt/irods-externals/clang13.0.0-0/bin:$PATH
+  #     export PATH=/opt/irods-externals/clang13.0.1-0/bin:$PATH
   #
   # - or -
   #
-  #     export ASAN_SYMBOLIZER_PATH=/opt/irods-externals/clang13.0.0-0/bin/llvm-symbolizer
+  #     export ASAN_SYMBOLIZER_PATH=/opt/irods-externals/clang13.0.1-0/bin/llvm-symbolizer
   #
   # detect_container_overflow is disabled to guard against false positives which occur when
   # parts of the binary are compiled with ASAN and other parts are not.
@@ -87,20 +88,16 @@ else()
   set(CMAKE_EXE_LINKER_FLAGS_INIT "${CMAKE_EXE_LINKER_FLAGS_INIT} -Wl,-z,defs")
 endif()
 
-set(IRODS_ENABLE_GENQUERY2 OFF CACHE BOOL "Enable GenQuery2 support. GenQuery2 package must be installed.")
-
 set(IRODS_HTTP_PROJECT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(IRODS_HTTP_PROJECT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 find_package(CURL REQUIRED)
 find_package(nlohmann_json "3.6.1" REQUIRED)
 
-if (${IRODS_VERSION} VERSION_GREATER "4.3.1")
-  find_package(fmt "8.1.1"
-    HINTS "${IRODS_EXTERNALS_FULLPATH_FMT}")
-  find_package(spdlog "1.9.2"
-    HINTS "${IRODS_EXTERNALS_FULLPATH_SPDLOG}")
-endif()
+find_package(fmt "8.1.1" REQUIRED
+  HINTS "${IRODS_EXTERNALS_FULLPATH_FMT}")
+find_package(spdlog "1.9.2" REQUIRED
+  HINTS "${IRODS_EXTERNALS_FULLPATH_SPDLOG}")
 
 find_package(OpenSSL REQUIRED COMPONENTS Crypto SSL)
 

--- a/README.md
+++ b/README.md
@@ -67,24 +67,18 @@ API documentation can be found in [API.md](./API.md).
 
 ## Build Dependencies
 
-- iRODS development package
+- iRODS development package _(4.3.2 or later)_
 - iRODS externals package for boost
 - iRODS externals package for nlohmann-json
 - iRODS externals package for spdlog 
 - Curl development package
 - OpenSSL development package
-- GenQuery2 package (optional)
 
 ## Build
 
-This project can be built with or without support for [GenQuery2](https://github.com/irods/irods_api_plugin_genquery2).
+**IMPORTANT: As documented under [Build Dependencies](#build-dependencies), the minimum version requirement for the iRODS development package is 4.3.2 or later. As a result, support for the [GenQuery2 API plugin](https://github.com/irods/irods_api_plugin_genquery2) has been removed. To use GenQuery2, the iRODS HTTP API must be connected to a server running iRODS 4.3.2 or later.**
 
-GenQuery2 is disabled by default.
-
-### Building without GenQuery2
-
-If you don't need support for GenQuery2, follow the normal CMake steps.
-
+To build this project, follow the normal CMake build steps.
 ```bash
 mkdir build # Preferably outside of the repository
 cd build
@@ -94,26 +88,9 @@ make package # Use -j to use more parallelism.
 
 Upon success, you should have an installable package.
 
-### Building with GenQuery2
-
-To build with GenQuery2 enabled, the HTTP API needs access to files only provided by the GenQuery2 package.
-
-If you haven't already done so, install the GenQuery2 package. See the [GenQuery2](https://github.com/irods/irods_api_plugin_genquery2) repository for details on how to do that.
-
-Now, run the following steps to produce an installable package.
-
-```bash
-mkdir build # Preferably outside of the repository
-cd build
-cmake -DIRODS_ENABLE_GENQUERY2=YES /path/to/repository
-make package # Use -j to use more parallelism.
-```
-
-Keep in mind that even though you've compiled the HTTP API with support for GenQuery2, that is half the story. You must also install the GenQuery2 package on the iRODS server which the HTTP API will connect to and the iRODS Catalog Service Provider.
-
 ## Docker
 
-This project provides two Dockerfiles, one for building and one for running the application. GenQuery2 is enabled by default. As mentioned in the previous section, the iRODS server must have GenQuery2 installed before attempting to use the parser.
+This project provides two Dockerfiles, one for building and one for running the application.
 
 **IMPORTANT: All commands in the sections that follow assume you are located in the root of the repository.**
 
@@ -124,22 +101,21 @@ The builder image is responsible for building the iRODS HTTP API package. Before
 docker build -t irods-http-api-builder -f irods_builder.Dockerfile .
 ```
 
-With the builder image in hand, all that's left is to get the source code for the GenQuery2 project and HTTP API project. The builder image is designed to compile code sitting on your machine. This is important because it gives you the ability to build any fork or branch of the projects.
+With the builder image in hand, all that's left is to build the iRODS HTTP API project. The builder image is designed to compile code sitting on your machine. This is important because it gives you the ability to build any fork or branch of the project. **Keep in mind the [GenQuery2 API plugin](https://github.com/irods/irods_api_plugin_genquery2) is no longer supported.**
 
-Building the packages requires mounting the projects into the container at the appropriate locations. The command you run should look similar to the one below. Don't forget to create the directory which will hold your packages!
+Building the package requires mounting the project into the container at the appropriate location. The command you run should look similar to the one below. **Don't forget to create the directory which will hold your packages!**
 ```bash
 docker run -it --rm \
-    -v /path/to/irods_api_plugin_genquery2:/genquery2_source:ro \
     -v /path/to/irods_client_http_api:/http_api_source:ro \
     -v /path/to/packages_directory:/packages_output \
     irods-http-api-builder
 ```
 
-If everything succeeds, you will have two DEB packages in the local directory you mapped to **/packages_output**.
+If everything succeeds, you will have a DEB package in the local directory you mapped to **/packages_output**.
 
 ### The Runner Image
 
-The runner image is responsible for running the iRODS HTTP API. Building the runner image requires the DEB packages for GenQuery2 and the iRODS HTTP API to exist on the local machine. See the previous section for details on generating the packages.
+The runner image is responsible for running the iRODS HTTP API. Building the runner image requires the DEB package for the iRODS HTTP API to exist on the local machine. See the previous section for details on generating the package.
 
 To build the image, run the following command:
 ```bash

--- a/build_packages.sh
+++ b/build_packages.sh
@@ -2,20 +2,9 @@
 
 set -x
 
-# Compile the GenQuery2 project.
-mkdir /_build_genquery2
-cd /_build_genquery2
-cmake -GNinja /genquery2_source
-ninja package
-apt-get install -y ./*.deb
-cp ./*.deb /packages_output
-
-# Return to the root directory.
-cd /
-
 # Compile the HTTP API project.
 mkdir /_build_http_api
 cd /_build_http_api
-cmake -GNinja -DIRODS_ENABLE_GENQUERY2=YES /http_api_source
+cmake -GNinja /http_api_source
 ninja package
 cp ./*.deb /packages_output

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -51,26 +51,11 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_GREATER "4.3.1")
-  target_link_libraries(
-    irods_http_api_core
-    PUBLIC
-    fmt::fmt
-    spdlog::spdlog
-  )
-else()
-  target_link_libraries(
-    irods_http_api_core
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/lib/libfmt.so"
-  )
-
-  target_include_directories(
-    irods_http_api_core
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
+target_link_libraries(
+  irods_http_api_core
+  PUBLIC
+  fmt::fmt
+  spdlog::spdlog
+)
 
 set_target_properties(irods_http_api_core PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/authentication/CMakeLists.txt
+++ b/endpoints/authentication/CMakeLists.txt
@@ -29,19 +29,10 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_GREATER "4.3.1")
-  target_link_libraries(
-    irods_http_api_endpoint_authentication
-    PUBLIC
-    fmt::fmt
-  )
-else()
-  target_include_directories(
-    irods_http_api_endpoint_authentication
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
+target_link_libraries(
+  irods_http_api_endpoint_authentication
+  PUBLIC
+  fmt::fmt
+)
 
 set_target_properties(irods_http_api_endpoint_authentication PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/collections/CMakeLists.txt
+++ b/endpoints/collections/CMakeLists.txt
@@ -28,13 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_collections
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
 set_target_properties(irods_http_api_endpoint_collections PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/data_objects/CMakeLists.txt
+++ b/endpoints/data_objects/CMakeLists.txt
@@ -28,13 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_data_objects
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
 set_target_properties(irods_http_api_endpoint_data_objects PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/information/CMakeLists.txt
+++ b/endpoints/information/CMakeLists.txt
@@ -28,17 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_information
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
-if (IRODS_ENABLE_GENQUERY2)
-  target_compile_definitions(irods_http_api_endpoint_information PRIVATE IRODS_ENABLE_GENQUERY2)
-endif()
-
 set_target_properties(irods_http_api_endpoint_information PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/information/src/main.cpp
+++ b/endpoints/information/src/main.cpp
@@ -34,18 +34,10 @@ namespace irods::http::handler
 			res.set(field_type::content_type, "application/json");
 			res.keep_alive(_req.keep_alive());
 
-#ifdef IRODS_ENABLE_GENQUERY2
-#  define GENQUERY2_ENABLED true
-#else
-// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
-#  define GENQUERY2_ENABLED false
-#endif // IRODS_ENABLE_GENQUERY2
-
 			// clang-format off
 			res.body() = json{
 				{"api_version", irods::http::version::api_version},
 				{"build", irods::http::version::sha},
-				{"genquery2_enabled", GENQUERY2_ENABLED},
 				{"irods_zone", irods_client_config.at("zone")},
 				{"max_number_of_parallel_write_streams", irods_client_config.at("max_number_of_parallel_write_streams")},
 				{"max_number_of_rows_per_catalog_query", irods_client_config.at("max_number_of_rows_per_catalog_query")},

--- a/endpoints/query/CMakeLists.txt
+++ b/endpoints/query/CMakeLists.txt
@@ -28,17 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_query
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
-if (IRODS_ENABLE_GENQUERY2)
-  target_compile_definitions(irods_http_api_endpoint_query PRIVATE IRODS_ENABLE_GENQUERY2)
-endif()
-
 set_target_properties(irods_http_api_endpoint_query PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/resources/CMakeLists.txt
+++ b/endpoints/resources/CMakeLists.txt
@@ -28,13 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_resources
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
 set_target_properties(irods_http_api_endpoint_resources PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/rules/CMakeLists.txt
+++ b/endpoints/rules/CMakeLists.txt
@@ -28,13 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_rules
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
 set_target_properties(irods_http_api_endpoint_rules PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/shared/CMakeLists.txt
+++ b/endpoints/shared/CMakeLists.txt
@@ -28,13 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_shared_operations
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
 set_target_properties(irods_http_api_shared_operations PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/tickets/CMakeLists.txt
+++ b/endpoints/tickets/CMakeLists.txt
@@ -28,13 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_tickets
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
 set_target_properties(irods_http_api_endpoint_tickets PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/users_groups/CMakeLists.txt
+++ b/endpoints/users_groups/CMakeLists.txt
@@ -28,19 +28,10 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_GREATER "4.3.1")
-  target_link_libraries(
-    irods_http_api_endpoint_users_groups
-    PUBLIC
-    fmt::fmt
-  )
-else()
-  target_include_directories(
-    irods_http_api_endpoint_users_groups
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
+target_link_libraries(
+  irods_http_api_endpoint_users_groups
+  PUBLIC
+  fmt::fmt
+)
 
 set_target_properties(irods_http_api_endpoint_users_groups PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/endpoints/zones/CMakeLists.txt
+++ b/endpoints/zones/CMakeLists.txt
@@ -28,13 +28,4 @@ target_include_directories(
   "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
 )
 
-if (${IRODS_VERSION} VERSION_EQUAL "4.3.1")
-  target_include_directories(
-    irods_http_api_endpoint_zones
-    PRIVATE
-    "${IRODS_EXTERNALS_FULLPATH_FMT}/include"
-    "${IRODS_EXTERNALS_FULLPATH_SPDLOG}/include"
-  )
-endif()
-
 set_target_properties(irods_http_api_endpoint_zones PROPERTIES EXCLUDE_FROM_ALL TRUE)

--- a/irods_builder.Dockerfile
+++ b/irods_builder.Dockerfile
@@ -31,25 +31,23 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list
 
-ARG irods_version=4.3.1-0~jammy
+ARG irods_version=4.3.2-0~jammy
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
     apt-get install -y \
         apt-transport-https \
-        flex \
-        bison \
         g++-11 \
         gcc-11 \
         irods-dev=${irods_version} \
         irods-runtime=${irods_version} \
-        irods-externals-clang13.0.0-0 \
+        irods-externals-clang13.0.1-0 \
         irods-externals-cmake3.21.4-0 \
-        irods-externals-fmt8.1.1-0 \
+        irods-externals-fmt-libcxx8.1.1-1 \
         irods-externals-json3.10.4-0 \
         irods-externals-jwt-cpp0.6.99.0-0 \
-        irods-externals-nanodbc2.13.0-1 \
-        irods-externals-spdlog1.9.2-1 \
+        irods-externals-nanodbc-libcxx2.13.0-2 \
+        irods-externals-spdlog-libcxx1.9.2-2 \
         libcurl4-gnutls-dev \
         libssl-dev \
         libssl3 \

--- a/irods_runner.Dockerfile
+++ b/irods_runner.Dockerfile
@@ -33,7 +33,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list
 
-ARG irods_version=4.3.1-0~jammy
+ARG irods_version=4.3.2-0~jammy
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update && \
@@ -43,7 +43,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         gcc \
         gcc-11 \
         irods-runtime=${irods_version} \
-        irods-externals-clang-runtime13.0.0-0 \
+        irods-externals-clang-runtime13.0.1-0 \
     && \
     rm -rf /tmp/*
 

--- a/test/config.py
+++ b/test/config.py
@@ -25,7 +25,7 @@ test_config = {
     'irods_zone': 'tempZone',
     'irods_server_hostname': 'localhost',
 
-    'run_genquery2_tests': False
+    'run_genquery2_tests': True
 }
 
 schema = {


### PR DESCRIPTION
All tests pass _(excluding OIDC tests)_.

Docker-related changes work as well.