### PR TITLE
[#196] Implement incremental write loop for write operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,9 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
         // during a single read operation.
         "max_number_of_bytes_per_read_operation": 8192,
 
-        // The buffer size used for write operations.
-        "buffer_size_in_bytes_for_write_operations": 8192,
+        // The maximum number of bytes that can be written to a data object
+        // during a single write operation.
+        "max_number_of_bytes_per_write_operation": 8192,
 
         // The number of rows that can be returned by a General or Specific
         // query. If the client specifies a number greater than the value

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -474,7 +474,7 @@ constexpr auto default_jsonschema() -> std::string_view
                     "type": "integer",
                     "minimum": 1
                 }},
-                "buffer_size_in_bytes_for_write_operations": {{
+                "max_number_of_bytes_per_write_operation": {{
                     "type": "integer",
                     "minimum": 1
                 }},
@@ -492,7 +492,7 @@ constexpr auto default_jsonschema() -> std::string_view
                 "connection_pool",
                 "max_number_of_parallel_write_streams",
                 "max_number_of_bytes_per_read_operation",
-                "buffer_size_in_bytes_for_write_operations",
+                "max_number_of_bytes_per_write_operation",
                 "max_number_of_rows_per_catalog_query"
             ]
         }}
@@ -580,7 +580,7 @@ auto print_configuration_template() -> void
         "max_number_of_parallel_write_streams": 3,
 
         "max_number_of_bytes_per_read_operation": 8192,
-        "buffer_size_in_bytes_for_write_operations": 8192,
+        "max_number_of_bytes_per_write_operation": 8192,
 
         "max_number_of_rows_per_catalog_query": 15
     }}

--- a/endpoints/data_objects/src/main.cpp
+++ b/endpoints/data_objects/src/main.cpp
@@ -946,7 +946,7 @@ namespace
 
 				static const auto max_number_of_bytes_per_write =
 					irods::http::globals::configuration()
-						.at(json::json_pointer{"/irods_client/buffer_size_in_bytes_for_write_operations"})
+						.at(json::json_pointer{"/irods_client/max_number_of_bytes_per_write_operation"})
 						.get<std::int64_t>();
 
 				// clang-format off

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -2356,7 +2356,6 @@ class test_information_endpoint(unittest.TestCase):
         info = r.json()
         self.assertIn('api_version', info)
         self.assertIn('build', info)
-        self.assertIn('genquery2_enabled', info)
         self.assertIn('irods_zone', info)
         self.assertIn('max_number_of_parallel_write_streams', info)
         self.assertIn('max_number_of_rows_per_catalog_query', info)

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -1,7 +1,9 @@
 import config
 import irods_error_codes
 
+import base64
 import concurrent.futures
+import hashlib
 import http.client
 import json
 import logging
@@ -1647,6 +1649,181 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.logger.debug(r.content)
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+    def test_parallel_writes_with_data_exceeding_internal_write_threshold(self):
+        # This test assumes the HTTP API is configured to use a value smaller than
+        # 96kb for "/irods_client/buffer_size_in_bytes_for_write_operations". This is
+        # important because values greater than or equal to 96kb will result in the
+        # background thread pool only being used one time. This test is designed to
+        # force the HTTP API to schedule multiple writes across the thread pool.
+        #
+        # NOTE: This test DOES NOT and CANNOT confirm the background thread pool is
+        # being used because it does not have visibility into the server's internal
+        # mechanisms. Our only means of verification is by careful review of the log
+        # messages. The server is expected to output messages about multiple writes
+        # to the iRODS server. The thread ID should change from one write operation to
+        # the next.
+
+        headers = {'Authorization': f'Bearer {self.rodsuser_bearer_token}'}
+        data_object = f'/{self.zone_name}/home/{self.rodsuser_username}/incremental_writes_0.txt'
+
+        # Generate 96kb string.
+        # This is the data we'll upload to the HTTP API.
+        data96kb = ('A' * 32768) + ('B' * 32768) + ('C' * 32768)
+
+        # Calculate a checksum for data.
+        # The checksum will be used to confirm the data was uploaded correctly.
+        checksum = base64.b64encode(hashlib.sha256(data96kb.encode('utf-8')).digest()).decode('utf-8')
+        self.logger.debug(f'checksum = [{checksum}]')
+
+        # Indicates whether the parallel_write_shutdown operation needs to be called.
+        # This is used for clean up when errors occur.
+        invoke_parallel_write_shutdown = False
+
+        try:
+            # Tell the server we're about to do a parallel write.
+            stream_count = 3
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'parallel_write_init',
+                'lpath': data_object,
+                'stream-count': stream_count
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            parallel_write_handle = result['parallel_write_handle']
+
+            # Make sure the parallel_write_shutdown operation is invoked now that we
+            # have a parallel-write handle.
+            invoke_parallel_write_shutdown = True
+
+            # Write to the data object using the parallel write handle.
+            futures = []
+            with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+                chunk_size = len(data96kb) // stream_count
+                self.logger.debug(f'chunk size = [{chunk_size}]')
+                for i in range(stream_count):
+                    chunk_start = i * chunk_size
+                    futures.append(executor.submit(self.multipart_form_data_upload, **{
+                        'bearer_token': self.rodsuser_bearer_token,
+                        'fields': {
+                            'op': 'write',
+                            'parallel-write-handle': parallel_write_handle,
+                            'offset': chunk_start,
+                            'stream-index': i
+                        },
+                        'bytes': data96kb[chunk_start : chunk_start + chunk_size]
+                    }))
+
+                for f in concurrent.futures.as_completed(futures):
+                    result = f.result()
+                    self.logger.debug(result)
+                    self.assertEqual(result['irods_response']['status_code'], 0)
+
+            # End the parallel write.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'parallel_write_shutdown',
+                'parallel-write-handle': parallel_write_handle
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # The data object was closed successfully.
+            # Do not invoke the parallel_write_shutdown operation in the finally block.
+            invoke_parallel_write_shutdown = False
+
+            # Show the data was written to the iRODS server safely.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'calculate_checksum',
+                'lpath': data_object
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['checksum'][5:], checksum)
+
+        finally:
+            # End the parallel write in case something failed.
+            # This avoids leaking of parallel-write resources in the HTTP API server.
+            if invoke_parallel_write_shutdown:
+                r = requests.post(self.url_endpoint, headers=headers, data={
+                    'op': 'parallel_write_shutdown',
+                    'parallel-write-handle': parallel_write_handle
+                })
+                self.logger.debug(r.content)
+
+            # Remove the data object.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'remove',
+                'lpath': data_object,
+                'catalog-only': 0,
+                'no-trash': 1
+            })
+            self.logger.debug(r.content)
+
+    def test_non_parallel_writes_with_data_exceeding_internal_write_threshold(self):
+        # This test assumes the HTTP API is configured to use a value smaller than
+        # 64kb for "/irods_client/buffer_size_in_bytes_for_write_operations". This is
+        # important because values greater than or equal to 64kb will result in the
+        # background thread pool only being used one time. This test is designed to
+        # force the HTTP API to schedule multiple writes across the thread pool.
+        #
+        # NOTE: This test DOES NOT and CANNOT confirm the background thread pool is
+        # being used because it does not have visibility into the server's internal
+        # mechanisms. Our only means of verification is by careful review of the log
+        # messages. The server is expected to output messages about multiple writes
+        # to the iRODS server. The thread ID should change from one write operation to
+        # the next.
+
+        headers = {'Authorization': f'Bearer {self.rodsuser_bearer_token}'}
+        data_object = f'/{self.zone_name}/home/{self.rodsuser_username}/incremental_writes_1.txt'
+
+        # Generate 64kb of random bytes.
+        # This is the data we'll upload to the HTTP API.
+        data64kb = os.urandom(64 * 1024)
+
+        # Calculate a checksum for data.
+        # The checksum will be used to confirm the data was uploaded correctly.
+        checksum = base64.b64encode(hashlib.sha256(data64kb).digest()).decode('utf-8')
+        self.logger.debug(f'checksum = [{checksum}]')
+
+        try:
+            # Create a new data object holding the binary data.
+            # Use the "files" parameter to upload the data using multipart/form-data as
+            # the encoding. If the "data" parameter was used, the data would be encoded
+            # as application/x-www-form-urlencoded which could cause the data to be corrupted.
+            r = requests.post(self.url_endpoint, headers=headers, files={
+                'op': 'write',
+                'lpath': data_object,
+                'bytes': data64kb
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Show the data was written to the iRODS server safely.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'calculate_checksum',
+                'lpath': data_object
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['checksum'][5:], checksum)
+
+        finally:
+            # Remove the data object.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'remove',
+                'lpath': data_object,
+                'catalog-only': 0,
+                'no-trash': 1
+            })
+            self.logger.debug(r.content)
 
     def test_modifying_metadata_atomically(self):
         headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -1652,7 +1652,7 @@ class test_data_objects_endpoint(unittest.TestCase):
 
     def test_parallel_writes_with_data_exceeding_internal_write_threshold(self):
         # This test assumes the HTTP API is configured to use a value smaller than
-        # 96kb for "/irods_client/buffer_size_in_bytes_for_write_operations". This is
+        # 96kb for "/irods_client/max_number_of_bytes_per_write_operation". This is
         # important because values greater than or equal to 96kb will result in the
         # background thread pool only being used one time. This test is designed to
         # force the HTTP API to schedule multiple writes across the thread pool.
@@ -1766,7 +1766,7 @@ class test_data_objects_endpoint(unittest.TestCase):
 
     def test_non_parallel_writes_with_data_exceeding_internal_write_threshold(self):
         # This test assumes the HTTP API is configured to use a value smaller than
-        # 64kb for "/irods_client/buffer_size_in_bytes_for_write_operations". This is
+        # 64kb for "/irods_client/max_number_of_bytes_per_write_operation". This is
         # important because values greater than or equal to 64kb will result in the
         # background thread pool only being used one time. This test is designed to
         # force the HTTP API to schedule multiple writes across the thread pool.


### PR DESCRIPTION
All tests pass.

Considering the idea of passing an input struct rather than 10+ parameters. Not required, but much easier to deal with from a code standpoint and while reading. Can also handle this later.

TODO: Add tests which force the use of bg thread pool when writing to iRODS. The number of writes depend on the configuration of the HTTP API, so we'll need to document the assumptions of the test suite too.