### PR TITLE
[#73] Log IP address of incoming client request

### DIFF
--- a/core/include/irods/private/http_api/log.hpp
+++ b/core/include/irods/private/http_api/log.hpp
@@ -1,6 +1,8 @@
 #ifndef IRODS_HTTP_API_LOG_HPP
 #define IRODS_HTTP_API_LOG_HPP
 
+#include "irods/private/http_api/session.hpp"
+
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
@@ -43,6 +45,42 @@ namespace irods::http::log
 	constexpr auto critical(fmt::format_string<Args...> _format, Args&&... _args) -> void
 	{
 		spdlog::critical(_format, std::forward<Args>(_args)...);
+	} // critical
+
+	template <typename... Args>
+	constexpr auto trace(session& _sp, fmt::format_string<Args...> _format, Args&&... _args) -> void
+	{
+		spdlog::trace(fmt::format("[{}] {}", _sp.ip(), fmt::vformat(_format, fmt::make_format_args(_args...))));
+	} // trace
+
+	template <typename... Args>
+	constexpr auto info(session& _sp, fmt::format_string<Args...> _format, Args&&... _args) -> void
+	{
+		spdlog::info(fmt::format("[{}] {}", _sp.ip(), fmt::vformat(_format, fmt::make_format_args(_args...))));
+	} // info
+
+	template <typename... Args>
+	constexpr auto debug(session& _sp, fmt::format_string<Args...> _format, Args&&... _args) -> void
+	{
+		spdlog::debug(fmt::format("[{}] {}", _sp.ip(), fmt::vformat(_format, fmt::make_format_args(_args...))));
+	} // debug
+
+	template <typename... Args>
+	constexpr auto warn(session& _sp, fmt::format_string<Args...> _format, Args&&... _args) -> void
+	{
+		spdlog::warn(fmt::format("[{}] {}", _sp.ip(), fmt::vformat(_format, fmt::make_format_args(_args...))));
+	} // warn
+
+	template <typename... Args>
+	constexpr auto error(session& _sp, fmt::format_string<Args...> _format, Args&&... _args) -> void
+	{
+		spdlog::error(fmt::format("[{}] {}", _sp.ip(), fmt::vformat(_format, fmt::make_format_args(_args...))));
+	} // error
+
+	template <typename... Args>
+	constexpr auto critical(session& _sp, fmt::format_string<Args...> _format, Args&&... _args) -> void
+	{
+		spdlog::critical(fmt::format("[{}] {}", _sp.ip(), fmt::vformat(_format, fmt::make_format_args(_args...))));
 	} // critical
 } //namespace irods::http::log
 

--- a/core/include/irods/private/http_api/log.hpp
+++ b/core/include/irods/private/http_api/log.hpp
@@ -9,36 +9,6 @@
 
 namespace irods::http::log
 {
-	inline auto trace(const std::string_view _msg) -> void
-	{
-		spdlog::trace(_msg);
-	} // trace
-
-	inline auto info(const std::string_view _msg) -> void
-	{
-		spdlog::info(_msg);
-	} // trace
-
-	inline auto debug(const std::string_view _msg) -> void
-	{
-		spdlog::debug(_msg);
-	} // trace
-
-	inline auto warn(const std::string_view _msg) -> void
-	{
-		spdlog::warn(_msg);
-	} // trace
-
-	inline auto error(const std::string_view _msg) -> void
-	{
-		spdlog::error(_msg);
-	} // trace
-
-	inline auto critical(const std::string_view _msg) -> void
-	{
-		spdlog::critical(_msg);
-	} // trace
-
 	template <typename... Args>
 	constexpr auto trace(fmt::format_string<Args...> _format, Args&&... _args) -> void
 	{

--- a/core/src/session.cpp
+++ b/core/src/session.cpp
@@ -77,7 +77,7 @@ namespace irods::http
 		}
 
 		if (ec == boost::beast::http::error::body_limit) {
-			log::error("{}: Request constraint error: {}", __func__, ec.message());
+			log::error(*this, "{}: Request constraint error: {}", __func__, ec.message());
 			return;
 		}
 
@@ -93,17 +93,17 @@ namespace irods::http
 
 		// Print the headers.
 		for (auto&& h : req_.base()) {
-			log::debug("{}: Header: ({}, {})", __func__, h.name_string(), h.value());
+			log::debug(*this, "{}: Header: ({}, {})", __func__, h.name_string(), h.value());
 		}
 
 		// Print the components of the request URL.
-		log::debug("{}: Method: {}", __func__, req_.method_string());
-		log::debug("{}: Version: {}", __func__, req_.version());
-		log::debug("{}: Target: {}", __func__, req_.target());
-		log::debug("{}: Keep Alive: {}", __func__, req_.keep_alive());
-		log::debug("{}: Has Content Length: {}", __func__, req_.has_content_length());
-		log::debug("{}: Chunked: {}", __func__, req_.chunked());
-		log::debug("{}: Needs EOF: {}", __func__, req_.need_eof());
+		log::debug(*this, "{}: Method: {}", __func__, req_.method_string());
+		log::debug(*this, "{}: Version: {}", __func__, req_.version());
+		log::debug(*this, "{}: Target: {}", __func__, req_.target());
+		log::debug(*this, "{}: Keep Alive: {}", __func__, req_.keep_alive());
+		log::debug(*this, "{}: Has Content Length: {}", __func__, req_.has_content_length());
+		log::debug(*this, "{}: Chunked: {}", __func__, req_.chunked());
+		log::debug(*this, "{}: Needs EOF: {}", __func__, req_.need_eof());
 
 		namespace http = boost::beast::http;
 
@@ -127,7 +127,7 @@ namespace irods::http
 			send(irods::http::fail(http::status::not_found));
 		}
 		catch (const std::exception& e) {
-			log::error("{}: {}", __func__, e.what());
+			log::error(*this, "{}: {}", __func__, e.what());
 			send(irods::http::fail(http::status::internal_server_error));
 		}
 	} // on_read

--- a/core/src/session.cpp
+++ b/core/src/session.cpp
@@ -69,6 +69,8 @@ namespace irods::http
 
 	auto session::on_read(boost::beast::error_code ec, std::size_t bytes_transferred) -> void
 	{
+		namespace logging = irods::http::log;
+
 		boost::ignore_unused(bytes_transferred);
 
 		// This means they closed the connection
@@ -77,7 +79,7 @@ namespace irods::http
 		}
 
 		if (ec == boost::beast::http::error::body_limit) {
-			log::error(*this, "{}: Request constraint error: {}", __func__, ec.message());
+			logging::error(*this, "{}: Request constraint error: {}", __func__, ec.message());
 			return;
 		}
 
@@ -93,17 +95,17 @@ namespace irods::http
 
 		// Print the headers.
 		for (auto&& h : req_.base()) {
-			log::debug(*this, "{}: Header: ({}, {})", __func__, h.name_string(), h.value());
+			logging::debug(*this, "{}: Header: ({}, {})", __func__, h.name_string(), h.value());
 		}
 
 		// Print the components of the request URL.
-		log::debug(*this, "{}: Method: {}", __func__, req_.method_string());
-		log::debug(*this, "{}: Version: {}", __func__, req_.version());
-		log::debug(*this, "{}: Target: {}", __func__, req_.target());
-		log::debug(*this, "{}: Keep Alive: {}", __func__, req_.keep_alive());
-		log::debug(*this, "{}: Has Content Length: {}", __func__, req_.has_content_length());
-		log::debug(*this, "{}: Chunked: {}", __func__, req_.chunked());
-		log::debug(*this, "{}: Needs EOF: {}", __func__, req_.need_eof());
+		logging::debug(*this, "{}: Method: {}", __func__, req_.method_string());
+		logging::debug(*this, "{}: Version: {}", __func__, req_.version());
+		logging::debug(*this, "{}: Target: {}", __func__, req_.target());
+		logging::debug(*this, "{}: Keep Alive: {}", __func__, req_.keep_alive());
+		logging::debug(*this, "{}: Has Content Length: {}", __func__, req_.has_content_length());
+		logging::debug(*this, "{}: Chunked: {}", __func__, req_.chunked());
+		logging::debug(*this, "{}: Needs EOF: {}", __func__, req_.need_eof());
 
 		namespace http = boost::beast::http;
 
@@ -127,7 +129,7 @@ namespace irods::http
 			send(irods::http::fail(http::status::not_found));
 		}
 		catch (const std::exception& e) {
-			log::error(*this, "{}: {}", __func__, e.what());
+			logging::error(*this, "{}: {}", __func__, e.what());
 			send(irods::http::fail(http::status::internal_server_error));
 		}
 	} // on_read

--- a/endpoints/authentication/src/main.cpp
+++ b/endpoints/authentication/src/main.cpp
@@ -116,7 +116,7 @@ namespace irods::http::handler
 				error_log_itter = fmt::format_to(error_log_itter, ", Error URI [{}]", *error_uri);
 			}
 
-			log::warn(token_error_log);
+			log::warn(fmt::runtime(token_error_log));
 			return true;
 		}
 
@@ -295,7 +295,7 @@ namespace irods::http::handler
 							responses_iter = fmt::format_to(responses_iter, ", Error URI [{}]", error_uri_iter->second);
 						}
 
-						log::warn(responses);
+						log::warn(fmt::runtime(responses));
 
 						return _sess_ptr->send(fail(status_type::bad_request));
 					}

--- a/endpoints/authentication/src/main.cpp
+++ b/endpoints/authentication/src/main.cpp
@@ -42,8 +42,8 @@
 #include <vector>
 
 // clang-format off
-namespace beast = boost::beast; // from <boost/beast.hpp>
-namespace net   = boost::asio;  // from <boost/asio.hpp>
+namespace net     = boost::asio;  // from <boost/asio.hpp>
+namespace logging = irods::http::log;
 // clang-format on
 
 namespace irods::http::handler
@@ -70,7 +70,7 @@ namespace irods::http::handler
 		const auto parsed_uri{boost::urls::parse_uri(token_endpoint)};
 
 		if (parsed_uri.has_error()) {
-			log::error(
+			logging::error(
 				"{}: Error trying to parse token_endpoint [{}]. Please check configuration.", __func__, token_endpoint);
 			return {{"error", "bad endpoint"}};
 		}
@@ -89,7 +89,7 @@ namespace irods::http::handler
 
 		// Send request and Read back response
 		auto res{tcp_stream->communicate(req)};
-		log::debug("Got the following resp back: {}", res.body());
+		logging::debug("Got the following resp back: {}", res.body());
 
 		// JSONize response
 		return nlohmann::json::parse(res.body());
@@ -116,7 +116,7 @@ namespace irods::http::handler
 				error_log_itter = fmt::format_to(error_log_itter, ", Error URI [{}]", *error_uri);
 			}
 
-			log::warn(fmt::runtime(token_error_log));
+			logging::warn(fmt::runtime(token_error_log));
 			return true;
 		}
 
@@ -127,7 +127,7 @@ namespace irods::http::handler
 	{
 		std::string authorization{_encoded_data};
 		boost::trim(authorization);
-		log::debug("{}: Authorization value (trimmed): [{}]", __func__, authorization);
+		logging::debug("{}: Authorization value (trimmed): [{}]", __func__, authorization);
 
 		constexpr auto max_creds_size = 128;
 		std::uint64_t size{max_creds_size};
@@ -135,7 +135,7 @@ namespace irods::http::handler
 		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
 		const auto ec = irods::base64_decode(
 			reinterpret_cast<unsigned char*>(authorization.data()), authorization.size(), creds.data(), &size);
-		log::debug("{}: base64 - error code=[{}], decoded size=[{}]", __func__, ec, size);
+		logging::debug("{}: base64 - error code=[{}], decoded size=[{}]", __func__, ec, size);
 
 		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
 		std::string_view sv{reinterpret_cast<char*>(creds.data()), size};
@@ -169,7 +169,7 @@ namespace irods::http::handler
 	{
 		if (_req.method() == boost::beast::http::verb::get) {
 			if (!is_oidc_running_as_client()) {
-				log::error(*_sess_ptr, "{}: HTTP GET method cannot be used for Basic authentication.", __func__);
+				logging::error(*_sess_ptr, "{}: HTTP GET method cannot be used for Basic authentication.", __func__);
 				return _sess_ptr->send(fail(status_type::method_not_allowed));
 			}
 
@@ -203,7 +203,7 @@ namespace irods::http::handler
 					                             .get_ref<const std::string&>()};
 					const auto encoded_url{fmt::format("{}?{}", auth_endpoint, irods::http::url_encode_body(args))};
 
-					log::debug(*_sess_ptr, "{}: Proper redirect to [{}]", fn, encoded_url);
+					logging::debug(*_sess_ptr, "{}: Proper redirect to [{}]", fn, encoded_url);
 
 					response_type res{status_type::found, _req.version()};
 					res.set(field_type::server, irods::http::version::server_name);
@@ -224,7 +224,7 @@ namespace irods::http::handler
 
 					// Invalid/Fake request... Should have state query param
 					if (state_iter == std::end(url.query)) {
-						log::warn(
+						logging::warn(
 							*_sess_ptr,
 							"{}: Received an Authorization response with no 'state' query parameter. Ignoring.",
 							fn);
@@ -258,7 +258,7 @@ namespace irods::http::handler
 
 					// The state is invalid (i.e. doesn't exist, or have been used)
 					if (!is_state_valid(state_iter->second)) {
-						log::warn(
+						logging::warn(
 							*_sess_ptr,
 							"{}: Received an Authorization response with an invalid 'state' query parameter. Ignoring.",
 							fn);
@@ -274,7 +274,7 @@ namespace irods::http::handler
 
 						// Required error parameter missing, malformed response
 						if (error_iter == std::end(url.query)) {
-							log::warn(
+							logging::warn(
 								*_sess_ptr,
 								"{}: Received an Authorization response with no 'code' or 'error' query parameters. "
 								"Ignoring.",
@@ -299,7 +299,7 @@ namespace irods::http::handler
 							responses_iter = fmt::format_to(responses_iter, ", Error URI [{}]", error_uri_iter->second);
 						}
 
-						log::warn(*_sess_ptr, fmt::runtime(responses));
+						logging::warn(*_sess_ptr, fmt::runtime(responses));
 
 						return _sess_ptr->send(fail(status_type::bad_request));
 					}
@@ -341,7 +341,8 @@ namespace irods::http::handler
 								? decoded_token.at("preferred_username").get<const std::string>()
 								: ""};
 
-						log::error(*_sess_ptr, "{}: No irods user associated with authenticated user [{}].", fn, user);
+						logging::error(
+							*_sess_ptr, "{}: No irods user associated with authenticated user [{}].", fn, user);
 						return _sess_ptr->send(fail(status_type::bad_request));
 					}
 
@@ -378,7 +379,7 @@ namespace irods::http::handler
 					return _sess_ptr->send(fail(status_type::bad_request));
 				}
 
-				log::debug(*_sess_ptr, "{}: Authorization value: [{}]", fn, iter->value());
+				logging::debug(*_sess_ptr, "{}: Authorization value: [{}]", fn, iter->value());
 
 				// Basic Auth case
 				if (const auto pos{iter->value().find("Basic ")}; pos != std::string_view::npos) {
@@ -398,7 +399,7 @@ namespace irods::http::handler
 					//
 					// The error will occur when rc_switch_user is invoked on the non-existent user.
 					if ("anonymous" == username && password.empty()) {
-						log::trace(
+						logging::trace(
 							*_sess_ptr,
 							"{}: Detected the anonymous user account. Skipping auth check and returning token.",
 							fn);
@@ -476,7 +477,7 @@ namespace irods::http::handler
 
 							if (const auto ec = rc_check_auth_credentials(static_cast<RcComm*>(conn), &input, &correct);
 							    ec < 0) {
-								log::error(
+								logging::error(
 									*_sess_ptr,
 									"{}: Error verifying native authentication credentials for user [{}]: error code "
 									"[{}].",
@@ -485,14 +486,14 @@ namespace irods::http::handler
 									ec);
 							}
 							else {
-								log::debug(*_sess_ptr, "{}: correct = [{}]", fn, fmt::ptr(correct));
-								log::debug(*_sess_ptr, "{}: *correct = [{}]", fn, (correct ? *correct : -1));
+								logging::debug(*_sess_ptr, "{}: correct = [{}]", fn, fmt::ptr(correct));
+								logging::debug(*_sess_ptr, "{}: *correct = [{}]", fn, (correct ? *correct : -1));
 								login_successful = (correct && 1 == *correct);
 							}
 						}
 					}
 					catch (const irods::exception& e) {
-						log::error(
+						logging::error(
 							*_sess_ptr,
 							"{}: Error verifying native authentication credentials for user [{}]: {}",
 							fn,
@@ -500,7 +501,7 @@ namespace irods::http::handler
 							e.client_display_what());
 					}
 					catch (const std::exception& e) {
-						log::error(
+						logging::error(
 							*_sess_ptr,
 							"{}: Error verifying native authentication credentials for user [{}]: {}",
 							fn,
@@ -570,7 +571,8 @@ namespace irods::http::handler
 								? decoded_token.at("preferred_username").get<const std::string>()
 								: ""};
 
-						log::error(*_sess_ptr, "{}: No irods user associated with authenticated user [{}].", fn, user);
+						logging::error(
+							*_sess_ptr, "{}: No irods user associated with authenticated user [{}].", fn, user);
 						return _sess_ptr->send(fail(status_type::bad_request));
 					}
 
@@ -601,7 +603,7 @@ namespace irods::http::handler
 		}
 		else {
 			// Nothing recognized
-			log::error(*_sess_ptr, "{}: HTTP method not supported.", __func__);
+			logging::error(*_sess_ptr, "{}: HTTP method not supported.", __func__);
 			return _sess_ptr->send(fail(status_type::method_not_allowed));
 		}
 	} // authentication

--- a/endpoints/collections/src/main.cpp
+++ b/endpoints/collections/src/main.cpp
@@ -119,7 +119,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -129,7 +129,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -172,18 +172,18 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}, {"entries", entries}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -207,7 +207,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -217,7 +217,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -266,18 +266,18 @@ namespace
 						.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -301,7 +301,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -311,7 +311,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -361,7 +361,7 @@ namespace
 				// clang-format on
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -372,7 +372,7 @@ namespace
 				// clang-format on
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -383,7 +383,7 @@ namespace
 				// clang-format on
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -407,7 +407,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -417,7 +417,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -448,18 +448,18 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -483,7 +483,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -493,7 +493,7 @@ namespace
 			try {
 				const auto old_lpath_iter = _args.find("old-lpath");
 				if (old_lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [old-lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [old-lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -508,7 +508,7 @@ namespace
 
 				const auto new_lpath_iter = _args.find("new-lpath");
 				if (new_lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [new-lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [new-lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -518,7 +518,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::bad_request);
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
@@ -526,18 +526,18 @@ namespace
 				}
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -561,7 +561,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -571,7 +571,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -586,19 +586,19 @@ namespace
 
 				const auto entity_name_iter = _args.find("entity-name");
 				if (entity_name_iter == std::end(_args)) {
-					logging::error("{}: Missing [entity-name] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [entity-name] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
 				const auto perm_iter = _args.find("permission");
 				if (perm_iter == std::end(_args)) {
-					logging::error("{}: Missing [permission] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [permission] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
 				const auto perm_enum = irods::to_permission_enum(perm_iter->second);
 				if (!perm_enum) {
-					logging::error("{}: Invalid value for [permission] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Invalid value for [permission] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -615,25 +615,25 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const fs::filesystem_error& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.body() =
 						json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}
 							.dump();
 				}
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -657,7 +657,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -667,13 +667,13 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
 				const auto enable_iter = _args.find("enable");
 				if (enable_iter == std::end(_args)) {
-					logging::error("{}: Missing [enable] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [enable] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -697,7 +697,7 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -708,7 +708,7 @@ namespace
 				// clang-format off
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -719,7 +719,7 @@ namespace
 				// clang-format off
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -752,7 +752,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -762,7 +762,7 @@ namespace
 				try {
 					const auto lpath_iter = _args.find("lpath");
 					if (lpath_iter == std::end(_args)) {
-						logging::error("{}: Missing [lpath] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -776,7 +776,7 @@ namespace
 						}
 						catch (const std::exception& e) {
 							logging::error(
-								"{}: Could not convert seconds-since-epoch [{}] into an integer.",
+								*_sess_ptr, "{}: Could not convert seconds-since-epoch [{}] into an integer.",
 								fn,
 								opt_iter->second);
 							return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
@@ -806,7 +806,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -817,7 +817,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/endpoints/data_objects/src/main.cpp
+++ b/endpoints/data_objects/src/main.cpp
@@ -687,7 +687,7 @@ namespace
 							out_ptr = &iter->second.streams.at(sindex)->stream();
 						}
 						catch (const std::exception& e) {
-							logging::error("{}: Invalid argument for [stream-index] parameter.");
+							logging::error("{}: Invalid argument for [stream-index] parameter.", fn);
 							return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 						}
 					}

--- a/endpoints/information/src/main.cpp
+++ b/endpoints/information/src/main.cpp
@@ -51,7 +51,7 @@ namespace irods::http::handler
 			return _sess_ptr->send(std::move(res));
 		}
 		catch (const std::exception& e) {
-			log::error("{}: {}", __func__, e.what());
+			log::error(*_sess_ptr, "{}: {}", __func__, e.what());
 			return _sess_ptr->send(irods::http::fail(boost::beast::http::status::internal_server_error));
 		}
 	} // information

--- a/endpoints/information/src/main.cpp
+++ b/endpoints/information/src/main.cpp
@@ -18,9 +18,11 @@ namespace irods::http::handler
 	// NOLINTNEXTLINE(performance-unnecessary-value-param)
 	IRODS_HTTP_API_ENDPOINT_ENTRY_FUNCTION_SIGNATURE(information)
 	{
+		namespace logging = irods::http::log;
+
 		try {
 			if (_req.method() != boost::beast::http::verb::get) {
-				log::error("{}: HTTP method not supported.", __func__);
+				logging::error("{}: HTTP method not supported.", __func__);
 				return _sess_ptr->send(fail(status_type::method_not_allowed));
 			}
 
@@ -51,7 +53,7 @@ namespace irods::http::handler
 			return _sess_ptr->send(std::move(res));
 		}
 		catch (const std::exception& e) {
-			log::error(*_sess_ptr, "{}: {}", __func__, e.what());
+			logging::error(*_sess_ptr, "{}: {}", __func__, e.what());
 			return _sess_ptr->send(irods::http::fail(boost::beast::http::status::internal_server_error));
 		}
 	} // information

--- a/endpoints/query/src/main.cpp
+++ b/endpoints/query/src/main.cpp
@@ -101,13 +101,13 @@ namespace
 		}
 
 		const auto client_info = result.client_info;
-		logging::info("{}: client_info.username = [{}]", __func__, client_info.username);
+		logging::info(*_sess_ptr, "{}: client_info.username = [{}]", __func__, client_info.username);
 
 		irods::http::globals::background_task(
 			[fn = __func__, _sess_ptr, req = std::move(_req), args = std::move(_args), client_info]() mutable {
 				auto query_iter = args.find("query");
 				if (query_iter == std::end(args)) {
-					logging::error("{}: Missing [query] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [query] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 				}
 
@@ -115,7 +115,7 @@ namespace
 				const auto parser_iter = args.find("parser");
 				if (parser_iter != std::end(args)) {
 					if (parser_iter->second != "genquery1" && parser_iter->second != "genquery2") {
-						logging::error("{}: Invalid argument for [parser] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Invalid argument for [parser] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -178,7 +178,8 @@ namespace
 								offset = std::stoi(iter->second);
 							}
 							catch (const std::exception& e) {
-								logging::error("{}: Could not convert [offset] parameter value into an integer. ", fn);
+								logging::error(
+									*_sess_ptr, "{}: Could not convert [offset] parameter value into an integer. ", fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -195,7 +196,8 @@ namespace
 								count = std::stoi(iter->second);
 							}
 							catch (const std::exception& e) {
-								logging::error("{}: Could not convert [count] parameter value into an integer.", fn);
+								logging::error(
+									*_sess_ptr, "{}: Could not convert [count] parameter value into an integer.", fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -211,7 +213,9 @@ namespace
 							}
 							else if (iter->second != "1") {
 								logging::error(
-									"{}: Invalid value for [case-sensitive] parameter. Expected a 1 or 0.", fn);
+									*_sess_ptr,
+									"{}: Invalid value for [case-sensitive] parameter. Expected a 1 or 0.",
+									fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -221,7 +225,8 @@ namespace
 								options |= NO_DISTINCT;
 							}
 							else if (iter->second != "1") {
-								logging::error("{}: Invalid value for [distinct] parameter. Expected a 1 or 0.", fn);
+								logging::error(
+									*_sess_ptr, "{}: Invalid value for [distinct] parameter. Expected a 1 or 0.", fn);
 								return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 							}
 						}
@@ -245,7 +250,7 @@ namespace
 					}
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -256,7 +261,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -274,11 +279,11 @@ namespace
 		}
 
 		const auto client_info = result.client_info;
-		logging::info("{}: client_info.username = [{}]", __func__, client_info.username);
+		logging::info(*_sess_ptr, "{}: client_info.username = [{}]", __func__, client_info.username);
 
 		const auto name_iter = _args.find("name");
 		if (name_iter == std::end(_args)) {
-			logging::error("{}: Missing [name] parameter.", __func__);
+			logging::error(*_sess_ptr, "{}: Missing [name] parameter.", __func__);
 			return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 		}
 
@@ -288,7 +293,8 @@ namespace
 				offset = std::stoi(iter->second);
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: Could not convert [offset] parameter value into an integer. ", __func__);
+				logging::error(
+					*_sess_ptr, "{}: Could not convert [offset] parameter value into an integer. ", __func__);
 				return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 			}
 		}
@@ -304,7 +310,7 @@ namespace
 				count = std::stoi(iter->second);
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: Could not convert [count] parameter value into an integer. ", __func__);
+				logging::error(*_sess_ptr, "{}: Could not convert [count] parameter value into an integer. ", __func__);
 				return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 			}
 		}
@@ -383,13 +389,13 @@ namespace
 				     rows}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -403,7 +409,7 @@ namespace
 	{
 		(void) _req;
 		(void) _args;
-		logging::error("{}: Operation not implemented.", __func__);
+		logging::error(*_sess_ptr, "{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 	} // op_list_genquery_columns
 
@@ -411,7 +417,7 @@ namespace
 	{
 		(void) _req;
 		(void) _args;
-		logging::error("{}: Operation not implemented.", __func__);
+		logging::error(*_sess_ptr, "{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 	} // op_list_specific_queries
 
@@ -426,7 +432,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, _sess_ptr, client_info, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -436,13 +442,13 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
 					const auto sql_iter = _args.find("sql");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [sql] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [sql] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -458,7 +464,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -469,7 +475,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -490,7 +496,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, _sess_ptr, client_info, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -500,7 +506,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -515,7 +521,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", ec}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -526,7 +532,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/endpoints/resources/src/main.cpp
+++ b/endpoints/resources/src/main.cpp
@@ -104,7 +104,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -114,13 +114,13 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
 					const auto type_iter = _args.find("type");
 					if (type_iter == std::end(_args)) {
-						logging::error("{}: Missing [type] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [type] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -153,13 +153,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -180,7 +180,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -190,7 +190,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -204,13 +204,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -234,7 +234,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -244,19 +244,19 @@ namespace
 			try {
 				const auto name_iter = _args.find("name");
 				if (name_iter == std::end(_args)) {
-					logging::error("{}: Missing [name] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 				}
 
 				const auto property_iter = _args.find("property");
 				if (property_iter == std::end(_args)) {
-					logging::error("{}: Missing [property] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [property] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 				}
 
 				const auto value_iter = _args.find("value");
 				if (value_iter == std::end(_args)) {
-					logging::error("{}: Missing [value] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [value] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 				}
 
@@ -302,6 +302,7 @@ namespace
 					}
 					else {
 						logging::error(
+							*_sess_ptr,
 							"{}: Invalid value for [value] parameter. Received [{}]. Expected [up] or [down] for "
 							"[status] property.",
 							fn,
@@ -332,7 +333,7 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.result(http::status::bad_request);
 				// clang-format off
 				res.body() = json{
@@ -344,7 +345,7 @@ namespace
 				// clang-format on
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -365,7 +366,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -375,13 +376,13 @@ namespace
 				try {
 					const auto parent_name_iter = _args.find("parent-name");
 					if (parent_name_iter == std::end(_args)) {
-						logging::error("{}: Missing [parent-name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [parent-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
 					const auto child_name_iter = _args.find("child-name");
 					if (child_name_iter == std::end(_args)) {
-						logging::error("{}: Missing [child-name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [child-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -403,13 +404,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -430,7 +431,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -440,13 +441,13 @@ namespace
 				try {
 					const auto parent_name_iter = _args.find("parent-name");
 					if (parent_name_iter == std::end(_args)) {
-						logging::error("{}: Missing [parent-name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [parent-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
 					const auto child_name_iter = _args.find("child-name");
 					if (child_name_iter == std::end(_args)) {
-						logging::error("{}: Missing [child-name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [child-name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -460,13 +461,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -487,7 +488,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -497,7 +498,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 					}
 
@@ -511,13 +512,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -541,7 +542,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -551,7 +552,7 @@ namespace
 			try {
 				const auto name_iter = _args.find("name");
 				if (name_iter == std::end(_args)) {
-					logging::error("{}: Missing [name] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(http::status::bad_request));
 				}
 
@@ -639,13 +640,13 @@ namespace
 				res.body() = json{{"irods_response", {{"status_code", 0}}}, {"exists", exists}, {"info", info}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/endpoints/rules/src/main.cpp
+++ b/endpoints/rules/src/main.cpp
@@ -104,7 +104,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -114,7 +114,7 @@ namespace
 			try {
 				const auto rule_text_iter = _args.find("rule-text");
 				if (rule_text_iter == std::end(_args)) {
-					logging::error("{}: Missing [rule-text] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [rule-text] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -160,19 +160,26 @@ namespace
 							if (exec_out->stdoutBuf.buf) {
 								stdout_output = static_cast<const char*>(exec_out->stdoutBuf.buf);
 								logging::debug(
-									"{}: stdout_output = [{}]", fn, stdout_output.get_ref<const std::string&>());
+									*_sess_ptr,
+									"{}: stdout_output = [{}]",
+									fn,
+									stdout_output.get_ref<const std::string&>());
 							}
 
 							if (exec_out->stderrBuf.buf) {
 								stderr_output = static_cast<const char*>(exec_out->stderrBuf.buf);
 								logging::debug(
-									"{}: stderr_output = [{}]", fn, stderr_output.get_ref<const std::string&>());
+									*_sess_ptr,
+									"{}: stderr_output = [{}]",
+									fn,
+									stderr_output.get_ref<const std::string&>());
 							}
 						}
 					}
 
 					if (auto* msp = getMsParamByLabel(out_param_array, "ruleExecOut"); msp) {
-						logging::debug("{}: ruleExecOut = [{}]", fn, static_cast<const char*>(msp->inOutStruct));
+						logging::debug(
+							*_sess_ptr, "{}: ruleExecOut = [{}]", fn, static_cast<const char*>(msp->inOutStruct));
 					}
 				}
 
@@ -180,7 +187,11 @@ namespace
 				if (auto* rerr_info = static_cast<RcComm*>(conn)->rError; rerr_info) {
 					for (auto&& err : std::span(rerr_info->errMsg, rerr_info->len)) {
 						logging::info(
-							"{}: RcComm::rError info = [status=[{}], message=[{}]]", fn, err->status, err->msg);
+							*_sess_ptr,
+							"{}: RcComm::rError info = [status=[{}], message=[{}]]",
+							fn,
+							err->status,
+							err->msg);
 					}
 
 					freeRError(rerr_info);
@@ -192,13 +203,13 @@ namespace
 						.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -219,7 +230,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -229,7 +240,7 @@ namespace
 				try {
 					const auto rule_id_iter = _args.find("rule-id");
 					if (rule_id_iter == std::end(_args)) {
-						logging::error("{}: Missing [rule-id] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [rule-id] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -246,13 +257,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -276,7 +287,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -330,13 +341,13 @@ namespace
 						.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 

--- a/endpoints/shared/src/shared_api_operations.cpp
+++ b/endpoints/shared/src/shared_api_operations.cpp
@@ -44,7 +44,7 @@ namespace irods::http::shared_api_operations
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _entity_type, _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				::http::response<::http::string_body> res{::http::status::ok, _req.version()};
 				res.set(::http::field::server, irods::http::version::server_name);
@@ -54,13 +54,13 @@ namespace irods::http::shared_api_operations
 				try {
 					const auto lpath_iter = _args.find("lpath");
 					if (lpath_iter == std::end(_args)) {
-						logging::error("{}: Missing [lpath] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
 					const auto operations_iter = _args.find("operations");
 					if (operations_iter == std::end(_args)) {
-						logging::error("{}: Missing [operations] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [operations] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
@@ -120,7 +120,7 @@ namespace irods::http::shared_api_operations
 					res.body() = response.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -131,7 +131,7 @@ namespace irods::http::shared_api_operations
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(::http::status::internal_server_error);
 				}
 
@@ -152,7 +152,7 @@ namespace irods::http::shared_api_operations
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _entity_type, _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				::http::response<::http::string_body> res{::http::status::ok, _req.version()};
 				res.set(::http::field::server, irods::http::version::server_name);
@@ -162,7 +162,7 @@ namespace irods::http::shared_api_operations
 				try {
 					const auto operations_iter = _args.find("operations");
 					if (operations_iter == std::end(_args)) {
-						logging::error("{}: Missing [operations] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [operations] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
@@ -192,13 +192,13 @@ namespace irods::http::shared_api_operations
 							break;
 
 						default:
-							logging::error("{}: Invalid entity type for atomic metadata operations.", fn);
+							logging::error(*_sess_ptr, "{}: Invalid entity type for atomic metadata operations.", fn);
 							return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
 					const auto entity_name_iter = _args.find(std::string{ename_param});
 					if (entity_name_iter == std::end(_args)) {
-						logging::error("{}: Missing [{}] parameter.", fn, ename_param);
+						logging::error(*_sess_ptr, "{}: Missing [{}] parameter.", fn, ename_param);
 						return _sess_ptr->send(irods::http::fail(res, ::http::status::bad_request));
 					}
 
@@ -234,7 +234,7 @@ namespace irods::http::shared_api_operations
 					res.body() = response.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -245,7 +245,7 @@ namespace irods::http::shared_api_operations
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(::http::status::internal_server_error);
 				}
 

--- a/endpoints/tickets/src/main.cpp
+++ b/endpoints/tickets/src/main.cpp
@@ -96,7 +96,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -106,7 +106,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -116,7 +116,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -127,7 +127,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		logging::error("{}: Operation not implemented.", __func__);
+		logging::error(*_sess_ptr, "{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_list
@@ -143,7 +143,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -153,7 +153,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -163,7 +163,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -174,7 +174,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		logging::error("{}: Operation not implemented.", __func__);
+		logging::error(*_sess_ptr, "{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_stat
@@ -193,7 +193,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -203,7 +203,7 @@ namespace
 			try {
 				const auto lpath_iter = _args.find("lpath");
 				if (lpath_iter == std::end(_args)) {
-					logging::error("{}: Missing [lpath] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [lpath] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -214,7 +214,7 @@ namespace
 						ticket_type = adm::ticket::ticket_type::write;
 					}
 					else if (type_iter->second != "read") {
-						logging::error("{}: Invalid value for [type] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Invalid value for [type] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 				}
@@ -258,7 +258,9 @@ namespace
 					const auto secs = std::stoll(constraint_iter->second);
 					if (secs <= 0) {
 						logging::error(
-							"{}: Invalid value for [seconds-until-expiration] parameter. Must be greater than 0.", fn);
+							*_sess_ptr,
+							"{}: Invalid value for [seconds-until-expiration] parameter. Must be greater than 0.",
+							fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -320,13 +322,13 @@ namespace
 				     ticket}}.dump();
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 						.dump();
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 
@@ -347,7 +349,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -357,7 +359,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -371,13 +373,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/endpoints/users_groups/src/main.cpp
+++ b/endpoints/users_groups/src/main.cpp
@@ -122,7 +122,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -132,13 +132,13 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						logging::error("{}: Missing [zone] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -152,7 +152,7 @@ namespace
 							user_type = adm::user_type::groupadmin;
 						}
 						else {
-							logging::error("{}: Invalid value for [user-type] parameter.", fn);
+							logging::error(*_sess_ptr, "{}: Invalid value for [user-type] parameter.", fn);
 							return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 						}
 					}
@@ -175,7 +175,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -186,7 +186,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -207,7 +207,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -217,13 +217,13 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						logging::error("{}: Missing [zone] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -239,7 +239,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -250,7 +250,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -271,7 +271,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -281,19 +281,19 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						logging::error("{}: Missing [zone] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto new_password_iter = _args.find("new-password");
 					if (new_password_iter == std::end(_args)) {
-						logging::error("{}: Missing [new-password] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [new-password] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -309,7 +309,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -320,7 +320,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -341,7 +341,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -351,19 +351,19 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						logging::error("{}: Missing [zone] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto new_user_type_iter = _args.find("new-user-type");
 					if (new_user_type_iter == std::end(_args)) {
-						logging::error("{}: Missing [new-user-type] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [new-user-type] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -381,7 +381,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -392,7 +392,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -413,7 +413,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -423,7 +423,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -433,7 +433,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -444,7 +444,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		logging::error("{}: Operation not implemented.", __func__);
+		logging::error(*_sess_ptr, "{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_add_user_auth
@@ -460,7 +460,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -470,7 +470,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -480,7 +480,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -491,7 +491,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		logging::error("{}: Operation not implemented.", __func__);
+		logging::error(*_sess_ptr, "{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_remove_user_auth
@@ -507,7 +507,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -517,7 +517,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -533,7 +533,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -544,7 +544,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -565,7 +565,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -575,7 +575,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -591,7 +591,7 @@ namespace
 					// clang-format on
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -602,7 +602,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -623,7 +623,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -633,19 +633,19 @@ namespace
 				try {
 					const auto user_iter = _args.find("user");
 					if (user_iter == std::end(_args)) {
-						logging::error("{}: Missing [user] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [user] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						logging::error("{}: Missing [zone] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto group_iter = _args.find("group");
 					if (group_iter == std::end(_args)) {
-						logging::error("{}: Missing [group] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [group] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -660,13 +660,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -687,7 +687,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -697,19 +697,19 @@ namespace
 				try {
 					const auto user_iter = _args.find("user");
 					if (user_iter == std::end(_args)) {
-						logging::error("{}: Missing [user] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [user] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						logging::error("{}: Missing [zone] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto group_iter = _args.find("group");
 					if (group_iter == std::end(_args)) {
-						logging::error("{}: Missing [group] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [group] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -724,13 +724,13 @@ namespace
 						 }}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -751,7 +751,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -772,13 +772,13 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"users", v}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -799,7 +799,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -820,13 +820,13 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}, {"groups", v}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -847,7 +847,7 @@ namespace
         const auto client_info = result.client_info;
 
         irods::http::globals::background_task([fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-            logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+            logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
             http::response<http::string_body> res{http::status::ok, _req.version()};
             res.set(http::field::server, irods::http::version::server_name);
@@ -857,7 +857,7 @@ namespace
             try {
             }
             catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
                 res.result(http::status::bad_request);
                 res.body() = json{
                     {"irods_response", {
@@ -867,7 +867,7 @@ namespace
                 }.dump();
             }
             catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
                 res.result(http::status::internal_server_error);
             }
 
@@ -878,7 +878,7 @@ namespace
 #else
 		(void) _req;
 		(void) _args;
-		logging::error("{}: Operation not implemented.", __func__);
+		logging::error(*_sess_ptr, "{}: Operation not implemented.", __func__);
 		return _sess_ptr->send(irods::http::fail(http::status::not_implemented));
 #endif
 	} // op_members
@@ -894,7 +894,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -904,19 +904,19 @@ namespace
 				try {
 					const auto group_iter = _args.find("group");
 					if (group_iter == std::end(_args)) {
-						logging::error("{}: Missing [group] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [group] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto user_iter = _args.find("user");
 					if (user_iter == std::end(_args)) {
-						logging::error("{}: Missing [user] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [user] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto zone_iter = _args.find("zone");
 					if (zone_iter == std::end(_args)) {
-						logging::error("{}: Missing [zone] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [zone] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -932,13 +932,13 @@ namespace
 							.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -959,7 +959,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -969,7 +969,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -1021,13 +1021,13 @@ namespace
 					res.body() = info.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					res.body() = json{{"irods_response",
 				                       {{"status_code", e.code()}, {"status_message", e.client_display_what()}}}}
 				                     .dump();
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 

--- a/endpoints/zones/src/main.cpp
+++ b/endpoints/zones/src/main.cpp
@@ -98,7 +98,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -108,7 +108,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -130,7 +130,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -141,7 +141,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -162,7 +162,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -172,7 +172,7 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -182,7 +182,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -193,7 +193,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -214,7 +214,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -224,19 +224,19 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto property_iter = _args.find("property");
 					if (property_iter == std::end(_args)) {
-						logging::error("{}: Missing [property] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [property] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto value_iter = _args.find("value");
 					if (value_iter == std::end(_args)) {
-						logging::error("{}: Missing [value] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [value] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -253,14 +253,14 @@ namespace
 						adm::client::modify_zone(conn, name_iter->second, adm::comment_property{value_iter->second});
 					}
 					else {
-						logging::error("{}: Invalid value for [property] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Invalid value for [property] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -271,7 +271,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -294,7 +294,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -304,20 +304,20 @@ namespace
 				try {
 					const auto name_iter = _args.find("name");
 					if (name_iter == std::end(_args)) {
-						logging::error("{}: Missing [name] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					const auto perm_iter = _args.find("permission");
 					if (perm_iter == std::end(_args)) {
-						logging::error("{}: Missing [permission] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [permission] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
 					// TODO(#291) Investigate whether fully-qualified usernames are supported.
 					const auto user_iter = _args.find("user");
 					if (user_iter == std::end(_args)) {
-						logging::error("{}: Missing [user] parameter.", fn);
+						logging::error(*_sess_ptr, "{}: Missing [user] parameter.", fn);
 						return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 					}
 
@@ -327,6 +327,7 @@ namespace
 					}
 					else if (perm_iter->second != "null") {
 						logging::error(
+							*_sess_ptr,
 							"{}: Invalid value for [permission] parameter. Received [{}]. Expected [null] or [read].",
 							fn,
 							perm_iter->second);
@@ -341,7 +342,7 @@ namespace
 					res.body() = json{{"irods_response", {{"status_code", 0}}}}.dump();
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -352,7 +353,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -374,7 +375,7 @@ namespace
 
 		irods::http::globals::background_task(
 			[fn = __func__, client_info, _sess_ptr, _req = std::move(_req), _args = std::move(_args)] {
-				logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+				logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 				http::response<http::string_body> res{http::status::ok, _req.version()};
 				res.set(http::field::server, irods::http::version::server_name);
@@ -389,7 +390,7 @@ namespace
 						auto conn = irods::get_connection(client_info.username);
 
 						if (const auto ec = rcZoneReport(static_cast<RcComm*>(conn), &bbuf); ec != 0) {
-							logging::error("{}: rcZoneReport error: [{}]", fn, ec);
+							logging::error(*_sess_ptr, "{}: rcZoneReport error: [{}]", fn, ec);
 							// clang-format off
 							res.body() = json{
 								{"irods_response", {
@@ -408,7 +409,7 @@ namespace
 						std::string_view(static_cast<char*>(bbuf->buf), bbuf->len));
 				}
 				catch (const irods::exception& e) {
-					logging::error("{}: {}", fn, e.client_display_what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 					// clang-format off
 					res.body() = json{
 						{"irods_response", {
@@ -419,7 +420,7 @@ namespace
 					// clang-format on
 				}
 				catch (const std::exception& e) {
-					logging::error("{}: {}", fn, e.what());
+					logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 					res.result(http::status::internal_server_error);
 				}
 
@@ -443,7 +444,7 @@ namespace
 		                                       _sess_ptr,
 		                                       _req = std::move(_req),
 		                                       _args = std::move(_args)] {
-			logging::info("{}: client_info.username = [{}]", fn, client_info.username);
+			logging::info(*_sess_ptr, "{}: client_info.username = [{}]", fn, client_info.username);
 
 			http::response<http::string_body> res{http::status::ok, _req.version()};
 			res.set(http::field::server, irods::http::version::server_name);
@@ -453,7 +454,7 @@ namespace
 			try {
 				const auto name_iter = _args.find("name");
 				if (name_iter == std::end(_args)) {
-					logging::error("{}: Missing [name] parameter.", fn);
+					logging::error(*_sess_ptr, "{}: Missing [name] parameter.", fn);
 					return _sess_ptr->send(irods::http::fail(res, http::status::bad_request));
 				}
 
@@ -490,7 +491,7 @@ namespace
 				// clang-format on
 			}
 			catch (const irods::exception& e) {
-				logging::error("{}: {}", fn, e.client_display_what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.client_display_what());
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {
@@ -501,7 +502,7 @@ namespace
 				// clang-format on
 			}
 			catch (const std::exception& e) {
-				logging::error("{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
 				res.result(http::status::internal_server_error);
 			}
 


### PR DESCRIPTION
This PR results in many log messages reporting the IP address like so:
```
[2024-08-21 09:38:18.634] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Header: (User-Agent, python-requests/2.31.0)
[2024-08-21 09:38:18.634] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Header: (Accept-Encoding, gzip, deflate)
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Header: (Accept, */*)
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Header: (Connection, keep-alive)
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Header: (Authorization, Bearer e2887051-ea00-41cb-91c1-0fb6aebca57a)
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Header: (Content-Length, 25)
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Header: (Content-Type, application/x-www-form-urlencoded)
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Method: POST
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Version: 11
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Target: /irods-http-api/0.3.0/zones
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Keep Alive: true
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Has Content Length: true
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Chunked: false
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] [127.0.0.1] on_read: Needs EOF: false
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] resolve_client_identity: Authorization value: [Bearer e2887051-ea00-41cb-91c1-0fb6aebca57a]
[2024-08-21 09:38:18.635] [P:1374617] [debug] [T:1374660] resolve_client_identity: Bearer token: [e2887051-ea00-41cb-91c1-0fb6aebca57a]
[2024-08-21 09:38:18.635] [P:1374617] [trace] [T:1374660] resolve_client_identity: Client is authenticated.
[2024-08-21 09:38:18.635] [P:1374617] [info] [T:1374653] [127.0.0.1] op_remove: client_info.username = [rods]
```