### PR TITLE
[#293] Make user mapping defined by plugin

### DIFF
--- a/API.md
+++ b/API.md
@@ -99,7 +99,7 @@ Bearer token when querying the HTTP API endpoints.
 
 In order for the access token to be accepted, two conditions must be met:
 1. The OpenID Provider recognizes the token as valid and active.
-2. The token must be able to be mapped to a user, using either `irods_user_claim` or `user_attribute_mapping`. 
+2. The token must be able to be mapped to a local zone user using a valid user mapping plugin.
 
 If these conditions are met, then the access token will be accepted, and the action will be carried out as the mapped
 user.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ include(ObjectTargetHelpers)
 
 add_subdirectory(core)
 add_subdirectory(endpoints)
+add_subdirectory(plugins)
 
 add_executable(${IRODS_HTTP_API_BINARY_NAME})
 target_link_objects(

--- a/core/include/irods/private/http_api/globals.hpp
+++ b/core/include/irods/private/http_api/globals.hpp
@@ -5,6 +5,7 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/thread_pool.hpp>
+#include <boost/dll.hpp>
 #include <nlohmann/json.hpp>
 
 #include <functional>
@@ -29,6 +30,9 @@ namespace irods::http::globals
 
 	auto set_oidc_configuration(const nlohmann::json& _config) -> void;
 	auto oidc_configuration() -> const nlohmann::json&;
+
+	auto set_user_mapping_lib(boost::dll::shared_library _lib) -> void;
+	auto user_mapping_lib() -> boost::dll::shared_library&;
 } // namespace irods::http::globals
 
 #endif // IRODS_HTTP_API_GLOBALS_HPP

--- a/core/src/globals.cpp
+++ b/core/src/globals.cpp
@@ -21,6 +21,9 @@ namespace
 
 	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
 	const nlohmann::json* g_oidc_endpoints{};
+
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	boost::dll::shared_library g_user_map_lib;
 } // anonymous namespace
 
 namespace irods::http::globals
@@ -95,4 +98,14 @@ namespace irods::http::globals
 	{
 		return *g_oidc_config;
 	} // oidc_configuration
+
+	auto set_user_mapping_lib(boost::dll::shared_library _lib) -> void
+	{
+		g_user_map_lib = std::move(_lib);
+	} // set_user_mapping_lib
+
+	auto user_mapping_lib() -> boost::dll::shared_library&
+	{
+		return g_user_map_lib;
+	} // user_mapping_lib
 } // namespace irods::http::globals

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,0 +1,8 @@
+include(GNUInstallDirs)
+
+set(
+  IRODS_HTTP_PLUGINS_DIRECTORY
+  "${CMAKE_INSTALL_LIBDIR}/irods_http_api/plugins"
+)
+
+add_subdirectory(user_mapping)

--- a/plugins/user_mapping/CMakeLists.txt
+++ b/plugins/user_mapping/CMakeLists.txt
@@ -1,0 +1,45 @@
+set(
+  IRODS_USER_MAPPING_PLUGINS
+  local_file
+  user_claim
+)
+
+foreach(plugin IN LISTS IRODS_USER_MAPPING_PLUGINS)
+  string(TOUPPER ${plugin} PLUGIN_UPPERCASE)
+  set(plugin_target "irods_http_api_plugin-${plugin}")
+  set(plugin_name "irods_http_api_plugin-${plugin}")
+
+  add_library(
+    ${plugin_target}
+    MODULE
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/${plugin}.cpp"
+  )
+  set_property(TARGET ${plugin_target} PROPERTY LIBRARY_OUTPUT_NAME ${plugin_name})
+  target_link_libraries(
+    ${plugin_target}
+    PRIVATE
+    irods_common
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_filesystem.so"
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/lib/libboost_system.so"
+    fmt::fmt
+    ${CMAKE_DL_LIBS}
+  )
+  target_include_directories(
+    ${plugin_target}
+    PRIVATE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "${IRODS_EXTERNALS_FULLPATH_BOOST}/include"
+  )
+  target_compile_definitions(
+    ${plugin_target}
+    PRIVATE
+    ${IRODS_COMPILE_DEFINITIONS_PRIVATE}
+  )
+
+  install(
+    TARGETS
+    ${plugin_target}
+    LIBRARY
+    DESTINATION "${IRODS_HTTP_PLUGINS_DIRECTORY}/user_mapping"
+  )
+endforeach()

--- a/plugins/user_mapping/include/irods/http_api/plugins/user_mapping/interface.h
+++ b/plugins/user_mapping/include/irods/http_api/plugins/user_mapping/interface.h
@@ -1,0 +1,55 @@
+#ifndef IRODS_HTTP_API_USER_MAPPER_INTERFACE_H
+#define IRODS_HTTP_API_USER_MAPPER_INTERFACE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// Initializes the user mapping plugin.
+///
+/// \param[in] _args A C-string containing the JSON representing the configuration for the plugin.
+///                  The structure of the JSON depends on the requirements specified by the plugin.
+///
+/// \pre \p _args must be a non-null C-string that represents a JSON structure.
+///
+/// \returns A code representing the result of the operation.
+/// \retval  zero if initialization of the plugin was successful.
+/// \retval  non-zero if initialization of the plugin was not successful.
+int user_mapper_init(const char* _args);
+
+/// Matches the given information to a user.
+///
+/// \param[in]  _param A C-string containing the JSON representing information from an
+///                    authenticated OpenID User. This can either take the form of an
+///                    OpenID Access Token or ID Token.
+/// \param[out] _match A pointer to a C-string. Gives the irods username of the matched user.
+///                    Returns a nullptr if no match is found.
+///
+/// \pre The mapping plugin must have successfully been initialized beforehand.
+/// \pre \p _param must be a non-null C-string that represents a JSON structure.
+/// \pre \p _match must be a non-null pointer to a C-string.
+///
+/// \returns A code representing the result of the operation.
+/// \retval  zero if matching of the plugin was successful.
+/// \retval  non-zero if an error occurred while matching.
+int user_mapper_match(const char* _param, char** _match);
+
+/// Executes clean-up for the user mapping plugin.
+///
+/// \pre The mapping plugin must have successfully been initialized beforehand.
+///
+/// \returns A code representing the result of the operation.
+/// \retval  zero if closing of the plugin was successful.
+/// \retval  non-zero if closing of the plugin was not successful.
+int user_mapper_close();
+
+/// Frees a C-string generated from the user mapping plugin.
+///
+/// \param[in] _data A C-string originating from the user mapping plugin.
+void user_mapper_free(char* _data);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // IRODS_HTTP_API_USER_MAPPER_INTERFACE_H

--- a/plugins/user_mapping/src/local_file.cpp
+++ b/plugins/user_mapping/src/local_file.cpp
@@ -1,0 +1,188 @@
+#include "irods/http_api/plugins/user_mapping/interface.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+namespace
+{
+	struct user_profile
+	{
+		std::string irods_user_name;
+		nlohmann::json attributes;
+	};
+
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	std::filesystem::path file_path; // Path to the file containing mappings.
+
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	std::vector<user_profile> profile_list; // Represents the mappings of irods users to attributes.
+
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables, cert-err58-cpp)
+	std::shared_mutex list_mutex; // Ensures a write cannot happen while reads happen to profile_list and vice versa.
+
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	std::mutex update_mutex; // Allows for only one thread to run 'update()' at a time.
+
+	auto update() -> void;
+
+	auto init(const nlohmann::json& _config) -> void
+	{
+		const auto path{_config.find("file_path")};
+		if (path == std::end(_config)) {
+			throw std::logic_error{"Unable to find [file_path] in configuration."};
+		}
+
+		// Save file string
+		file_path = path->get<std::string>();
+
+		// If something is invalid with the file, fail fast via update
+		update();
+	} // init
+
+	auto update() -> void
+	{
+		static std::filesystem::file_time_type last_file_path_write;
+
+		// If there have been no changes to file_path, there is no work to do
+		if (std::filesystem::last_write_time(file_path) == last_file_path_write) {
+			spdlog::trace("{}: Mapping file has not been modified, skipping update.", __func__);
+			return;
+		}
+
+		spdlog::trace("{}: Mapping file modified, updating internal state.", __func__);
+
+		std::ifstream file{file_path};
+		if (!file) {
+			throw std::runtime_error{"Failed to open [file_path]."};
+		}
+
+		auto json_data{nlohmann::json::parse(file)};
+
+		// Create temp list to be swapped in later
+		std::vector<user_profile> temp_list;
+		temp_list.reserve(json_data.size());
+
+		// Process into list:
+		auto base_iter{json_data.items()};
+		std::transform(
+			std::begin(base_iter),
+			std::end(base_iter),
+			std::back_inserter(temp_list),
+			[](const auto& _iter) -> user_profile {
+				return {.irods_user_name = _iter.key(), .attributes = _iter.value()};
+			});
+
+		// Move new item list to old one, update last write time
+		std::unique_lock update_profile_list_lock{list_mutex};
+		profile_list = std::move(temp_list);
+		last_file_path_write = std::filesystem::last_write_time(file_path);
+	} // update
+
+	auto match(const nlohmann::json& _params) -> std::optional<std::string>
+	{
+		// If there is an exception while updating, catch so we can still
+		// provide matches with our current good state.
+		try {
+			// Only allow one thread to run update at a time
+			if (std::unique_lock call_update_lock{update_mutex, std::try_to_lock}; call_update_lock) {
+				update();
+			}
+		}
+		catch (const std::exception& e) {
+			spdlog::error("{}: {}", __func__, e.what());
+		}
+
+		std::shared_lock read_profile_list_lock{list_mutex};
+
+		// Use provided mappings to see if there is a complete match to a user
+		for (const auto& [irods_username, attributes] : profile_list) {
+			auto attr_iter{attributes.items()};
+
+			// Verify that each attribute specified is found in _params
+			auto res{std::all_of(std::begin(attr_iter), std::end(attr_iter), [&_params](const auto& _iter) -> bool {
+				const auto value_of_interest{_params.find(_iter.key())};
+				if (value_of_interest == std::end(_params)) {
+					return false;
+				}
+
+				return *value_of_interest == _iter.value();
+			})};
+
+			// If all specified attributes matched, _params maps to irods_username
+			if (res) {
+				return irods_username;
+			}
+		}
+
+		return std::nullopt;
+	} // match
+} // anonymous namespace
+
+auto user_mapper_init(const char* _args) -> int
+{
+	// Check if any of the args are nullptr
+	if (nullptr == _args) {
+		return 1;
+	}
+
+	try {
+		spdlog::debug("{}: Received _args [{}].", __func__, _args);
+		init(nlohmann::json::parse(_args));
+	}
+	catch (const std::exception& e) {
+		spdlog::error("{}: {}", __func__, e.what());
+		return 1;
+	}
+	return 0;
+} // user_mapper_init
+
+auto user_mapper_match(const char* _param, char** _match) -> int
+{
+	// Check if any of the args are nullptr
+	if (nullptr == _param || nullptr == _match) {
+		return 1;
+	}
+
+	spdlog::debug("{}: Attempting match of _param [{}].", __func__, _param);
+	try {
+		auto res{match(nlohmann::json::parse(_param))};
+
+		if (res) {
+			spdlog::debug("{}: Matched _param [{}] to user [{}].", __func__, _param, *res);
+			char* matched_username{strdup(res->c_str())};
+
+			*_match = matched_username;
+			return 0;
+		}
+
+		*_match = nullptr;
+		return 0;
+	}
+	catch (const std::exception& e) {
+		spdlog::error("{}: {}", __func__, e.what());
+		*_match = nullptr;
+		return 1;
+	}
+} // user_mapper_match
+
+auto user_mapper_close() -> int
+{
+	return 0;
+} // user_mapper_close
+
+auto user_mapper_free(char* _data) -> void
+{
+	// NOLINTNEXTLINE(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
+	std::free(_data);
+} // user_mapper_free

--- a/plugins/user_mapping/src/user_claim.cpp
+++ b/plugins/user_mapping/src/user_claim.cpp
@@ -1,0 +1,93 @@
+#include "irods/http_api/plugins/user_mapping/interface.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <optional>
+#include <string>
+
+#include <nlohmann/json.hpp>
+#include <spdlog/spdlog.h>
+
+namespace
+{
+	// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+	std::string claim_to_match;
+
+	auto init(const nlohmann::json& _config) -> void
+	{
+		const auto claim{_config.find("irods_user_claim")};
+		if (claim == std::end(_config)) {
+			throw std::logic_error{"Unable to find [irods_user_claim] in provided config."};
+		}
+
+		claim_to_match = claim->get<std::string>();
+	} // init
+
+	auto match(const nlohmann::json& _params) -> std::optional<std::string>
+	{
+		if (auto claim{_params.find(claim_to_match)}; claim != std::end(_params)) {
+			return claim->get<std::string>();
+		}
+
+		return std::nullopt;
+	} // match
+} // anonymous namespace
+
+auto user_mapper_init(const char* _args) -> int
+{
+	// Check if any of the args are nullptr
+	if (nullptr == _args) {
+		return 1;
+	}
+
+	try {
+		spdlog::debug("{}: Received _args [{}].", __func__, _args);
+		init(nlohmann::json::parse(_args));
+	}
+	catch (const std::exception& e) {
+		spdlog::error("{}: {}", __func__, e.what());
+		return 1;
+	}
+	return 0;
+} // user_mapper_init
+
+auto user_mapper_match(const char* _param, char** _match) -> int
+{
+	// Check if any of the args are nullptr
+	if (nullptr == _param || nullptr == _match) {
+		return 1;
+	}
+
+	spdlog::debug("{}: Attempting match of _param [{}].", __func__, _param);
+	try {
+		auto res{match(nlohmann::json::parse(_param))};
+
+		if (res) {
+			spdlog::debug("{}: Matched _param [{}] to user [{}].", __func__, _param, *res);
+			char* matched_username{strdup(res->c_str())};
+
+			*_match = matched_username;
+			return 0;
+		}
+
+		*_match = nullptr;
+		return 0;
+	}
+	catch (const std::exception& e) {
+		spdlog::error("{}: {}", __func__, e.what());
+		*_match = nullptr;
+		return 1;
+	}
+} // user_mapper_match
+
+auto user_mapper_close() -> int
+{
+	return 0;
+} // user_mapper_close
+
+auto user_mapper_free(char* _data) -> void
+{
+	// NOLINTNEXTLINE(cppcoreguidelines-no-malloc, cppcoreguidelines-owning-memory)
+	std::free(_data);
+} // user_mapper_free


### PR DESCRIPTION
This PR would move various implementations of user mapping to a separate shared library, allowing for user-defined plugins to be developed against the plugin interface.

A default 'local file' plugin would ship with the HTTP API, with behavior similar to `user_attribute_mapping`. The two changes would be that the mapping definition would live in a separate file, and be the file would be reread for changes. This would allow for the mapping to be updated without restarting the HTTP API.