### PR TITLE
[#335] Avoid infinite loop when listening socket is already bound

### DIFF
--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -105,35 +105,10 @@ class listener : public std::enable_shared_from_this<listener>
 	                         .get<int>()}
 		, timeout_in_secs_{_config.at(json::json_pointer{"/http_server/requests/timeout_in_seconds"}).get<int>()}
 	{
-		beast::error_code ec;
-
-		// Open the acceptor
-		acceptor_.open(endpoint.protocol(), ec);
-		if (ec) {
-			irods::fail(ec, "open");
-			return;
-		}
-
-		// Allow address reuse
-		acceptor_.set_option(net::socket_base::reuse_address(true), ec);
-		if (ec) {
-			irods::fail(ec, "set_option");
-			return;
-		}
-
-		// Bind to the server address
-		acceptor_.bind(endpoint, ec);
-		if (ec) {
-			irods::fail(ec, "bind");
-			return;
-		}
-
-		// Start listening for connections
-		acceptor_.listen(net::socket_base::max_listen_connections, ec);
-		if (ec) {
-			irods::fail(ec, "listen");
-			return;
-		}
+		acceptor_.open(endpoint.protocol());
+		acceptor_.set_option(net::socket_base::reuse_address(true));
+		acceptor_.bind(endpoint);
+		acceptor_.listen(net::socket_base::max_listen_connections);
 	} // listener (constructor)
 
 	// Start accepting incoming connections.


### PR DESCRIPTION
This change causes the server to terminate and print a message to the terminal when the socket is already bound by another instance. Admins can expect to see the following when this occurs.
```
Validating configuration file ...                                                                                                                                    
No JSON schema file provided. Using default.                                                                                                                         
Configuration passed validation!                                                                                                                                     
[2024-09-25 15:18:56.118] [P:581459] [info] [T:581459] Initializing server.                                                                                          
[2024-09-25 15:18:56.118] [P:581459] [trace] [T:581459] Verifying OIDC endpoint configuration                                                                        
[2024-09-25 15:18:56.118] [P:581459] [info] [T:581459] No OIDC configuration detected, running without OIDC features.                                                
[2024-09-25 15:18:56.118] [P:581459] [trace] [T:581459] Loading API plugins.                                                                                         
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Initializing TLS.                                                                                            
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Setting environment variable [IRODS_CLIENT_SERVER_POLICY] to [CS_NEG_REFUSE].                                
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Setting environment variable [IRODS_SSL_VERIFY_SERVER] to [cert].                                            
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Setting environment variable [IRODS_CLIENT_SERVER_NEGOTIATION] to [request_server_negotiation].              
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Setting environment variable [IRODS_ENCRYPTION_ALGORITHM] to [AES-256-CBC].                                  
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Setting environment variable [IRODS_ENCRYPTION_KEY_SIZE] to [32].                                            
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Setting environment variable [IRODS_ENCRYPTION_NUM_HASH_ROUNDS] to [16].                                     
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Setting environment variable [IRODS_ENCRYPTION_SALT_SIZE] to [8].                                            
[2024-09-25 15:18:56.157] [P:581459] [trace] [T:581459] Initializing iRODS connection pool.                                                                          
[2024-09-25 15:18:56.490] [P:581459] [trace] [T:581459] Initializing HTTP components.                                                                                
[2024-09-25 15:18:56.490] [P:581459] [trace] [T:581459] Initializing listening socket (host=[0.0.0.0], port=[9000]).                                                 
Error: bind: Address already in use [system:98 at /opt/irods-externals/boost1.81.0-1/include/boost/asio/detail/reactive_socket_service.hpp:161:33 in function 'bind']
```