### PR TITLE
[#269] Collapse version information to single point of control

### DIFF
--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -163,7 +163,7 @@ constexpr auto default_jsonschema() -> std::string_view
 	// clang-format on
 	return R"({{
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://schemas.irods.org/irods-http-api/0.4.0/schema.json",
+    "$id": "https://schemas.irods.org/irods-http-api/config.json",
     "type": "object",
     "properties": {{
         "http_server": {{

--- a/test/config.py
+++ b/test/config.py
@@ -6,7 +6,7 @@ test_config = {
 
     'host': 'localhost',
     'port': 9000,
-    'url_base': '/irods-http-api/0.4.0',
+    'url_base': '/irods-http-api/<version>',
 
     'openid_connect': {
         'mode': 'client'
@@ -30,7 +30,7 @@ test_config = {
 
 schema = {
     '$schema': 'http://json-schema.org/draft-07/schema#',
-    '$id': 'https://schemas.irods.org/irods-http-api/test/0.4.0/test-schema.json',
+    '$id': 'https://schemas.irods.org/irods-http-api/test_config.json',
     'type': 'object',
     'properties': {
         'host': {


### PR DESCRIPTION
- Schema files/info does not need to include version info
- Config file for testing does not need to include version info