### PR TITLE
[#243] Further document `tls_certificates_directory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,8 +269,10 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
                     }
                 },
 
-                // The path to the TLS certificates directory.
-                // Used for HTTPS connections.
+                // The path to the TLS certificates directory used to establish
+                // secure connections between the HTTP API and the OpenID provider.
+                // Typically, this should point to a standard certificate directory
+                // such as "/etc/ssl/cert".
                 "tls_certificates_directory": "/path/to/certs"
             }
         },


### PR DESCRIPTION
Make clear the use of `tls_certificates_directory`.