### PR TITLE
[#244] Provide clear message on OpenID connection error

### DIFF
--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -816,7 +816,11 @@ auto load_oidc_configuration(const json& _config, json& _oi_config, json& _endpo
 		irods::http::globals::set_oidc_endpoint_configuration(_endpoint_config);
 	}
 	catch (const json::out_of_range& e) {
-		logging::trace("Invalid OIDC configuration, ignoring. Reason: {}", e.what());
+		logging::info("Invalid OIDC configuration, ignoring. Reason: {}", e.what());
+		return false;
+	}
+	catch (const boost::beast::system_error& e) {
+		logging::error("Unable to establish connection to OpenID Provider. Reason: [{}]", e.what());
 		return false;
 	}
 


### PR DESCRIPTION
```
$ irods_http_api config.json 
Validating configuration file ...
No JSON schema file provided. Using default.
Configuration passed validation!
[2024-11-05 18:54:10.724] [P:15090] [info] [T:15090] Initializing server.
[2024-11-05 18:54:10.724] [P:15090] [trace] [T:15090] Verifying OIDC endpoint configuration
[2024-11-05 18:54:10.724] [P:15090] [trace] [T:15090] Unable to establish connection to OpenID Provider. Reason: [connect: Connection refused [system:111 at /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/reactive_socket_service.hpp:587:33 in function 'connect']]
[2024-11-05 18:54:10.724] [P:15090] [error] [T:15090] Invalid OIDC configuration, server not starting.
```