### PR TITLE
[#375] Add optional strict check to `aud` member of introspection endpoint response

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
                 // If provided, it MUST be base64url encoded.
                 "nonstandard_id_token_secret": "xxxxxxxxxxxxxxx",
 
+                // Controls whether the HTTP API requires the presence of the
+                // "aud" member in the introspection endpoint response. If set
+                // to true and the "aud" member is NOT present, the provided
+                // access token will be rejected.
+                "require_aud_member_from_introspection_endpoint": false,
+
                 // The OIDC mode the HTTP API will run as.
                 // The following values are supported:
                 // - client:              Run the HTTP API as an OIDC client

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -235,6 +235,9 @@ constexpr auto default_jsonschema() -> std::string_view
                                 "nonstandard_id_token_secret": {{
                                     "type": "string"
                                 }},
+                                "require_aud_member_from_introspection_endpoint": {{
+                                    "type": "boolean"
+                                }},
                                 "redirect_uri": {{
                                     "type": "string",
                                     "format": "uri"
@@ -264,6 +267,7 @@ constexpr auto default_jsonschema() -> std::string_view
                                 "provider_url",
                                 "mode",
                                 "client_id",
+                                "require_aud_member_from_introspection_endpoint",
                                 "redirect_uri",
                                 "tls_certificates_directory",
                                 "user_mapping"
@@ -508,6 +512,7 @@ auto print_configuration_template() -> void
                 "client_id": "<string>",
                 "client_secret": "<string>",
                 "mode": "client",
+                "require_aud_member_from_introspection_endpoint": false,
                 "redirect_uri": "<string>",
                 "user_mapping": {{
                     "plugin_path": "<string>",

--- a/core/src/openid.cpp
+++ b/core/src/openid.cpp
@@ -154,12 +154,16 @@ namespace irods::http::openid
 				logging::warn("{}: Could not find our [client_id] in [aud]. Validation failed.", __func__);
 				return std::nullopt;
 			}
+		}
 		// Some IAM servers (e.g. keycloak) could be set up
-		// to exclude `aud' from a bearer token payload 	
-		// If no 'aud' was found in bearer token, do not accept 
-		} else {
-		  logging::warn("{}: Bearer token payload is missing [aud]. Validation failed.", __func__);
-		  return std::nullopt;
+		// to exclude 'aud' from a bearer token payload.
+		// If no 'aud' was found in bearer token, do not accept.
+		else if (auto strict_aud{
+					 irods::http::globals::oidc_configuration().find("require_aud_member_from_introspection_endpoint")};
+		         strict_aud != std::end(irods::http::globals::oidc_configuration()) && strict_aud->get<bool>())
+		{
+			logging::warn("{}: Bearer token payload is missing [aud]. Validation failed.", __func__);
+			return std::nullopt;
 		}
 
 		// The 'iss' provided should match the 'issuer' retrieved from the OpenID Provider's


### PR DESCRIPTION
This has the changes made from #376, with the suggestions of that PR applied in this PR.