### PR TITLE
[#389] Fix KeyVal memory leak

### DIFF
--- a/endpoints/data_objects/src/main.cpp
+++ b/endpoints/data_objects/src/main.cpp
@@ -1616,6 +1616,7 @@ namespace
 
 				try {
 					DataObjInp input{};
+					irods::at_scope_exit free_memory{[&input] { clearKeyVal(&input.condInput); }};
 
 					if (const auto lpath_iter = _args.find("lpath"); lpath_iter != std::end(_args)) {
 						irods::strncpy_null_terminated(input.objPath, lpath_iter->second.c_str());


### PR DESCRIPTION
Found using ASAN, logs follow:

```
=================================================================
==7599==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 320 byte(s) in 4 object(s) allocated from:
    #0 0x763a3f in __interceptor_realloc /externals/clang13.0.1-0_src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:148:3
    #1 0x7dbb2affc056 in addKeyVal (/lib/libirods_common.so.4.3.2+0x174056)
    #2 0xc6c323 in decltype(static_cast<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>(fp)()) std::__1::__invoke<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>((anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&) /opt/irods-externals/clang13.0.1-0/include/c++/v1/type_traits:3934:1
    #3 0xc6c323 in void std::__1::__invoke_void_return_wrapper<void, true>::__call<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>((anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&) /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/invoke.h:61:9
    #4 0xc6c323 in std::__1::__function::__alloc_func<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8, std::__1::allocator<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8>, void ()>::operator()() /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:171:16
    #5 0xc6c323 in std::__1::__function::__func<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8, std::__1::allocator<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8>, void ()>::operator()() /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:345:12
    #6 0x95fe89 in std::__1::__function::__value_func<void ()>::operator()() const /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:498:16
    #7 0x95f418 in std::__1::function<void ()>::operator()() const /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:1175:12
    #8 0x95f418 in irods::http::globals::background_task(std::__1::function<void ()>)::$_0::operator()() const /workspaces/irods_client_http_api/core/src/globals.cpp:65:5
    #9 0x95f418 in boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>::operator()() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/bind_handler.hpp:60:5
    #10 0x95f5cb in void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>, boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0> >(boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>&, boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/handler_invoke_helpers.hpp:51:3
    #11 0x95f5cb in boost::asio::detail::executor_op<boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/executor_op.hpp:70:7
    #12 0x9ae98a in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/scheduler_operation.hpp:40:5
    #13 0x9ae98a in boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/scheduler.ipp:492:12
    #14 0x9ae02c in boost::asio::detail::scheduler::run(boost::system::error_code&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/scheduler.ipp:210:10
    #15 0x9eddf8 in boost::asio::thread_pool::thread_function::operator()() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/impl/thread_pool.ipp:39:19
    #16 0x9edc93 in boost::asio::detail::posix_thread::func<boost::asio::thread_pool::thread_function>::run() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/posix_thread.hpp:86:7
    #17 0x9ad818 in boost_asio_detail_posix_thread_function /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/posix_thread.ipp:74:13
    #18 0x7dbb2a527ac2 in start_thread nptl/./nptl/pthread_create.c:442:8

Direct leak of 320 byte(s) in 4 object(s) allocated from:
    #0 0x763a3f in __interceptor_realloc /externals/clang13.0.1-0_src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:148:3
    #1 0x7dbb2affc06e in addKeyVal (/lib/libirods_common.so.4.3.2+0x17406e)
    #2 0xc6c323 in decltype(static_cast<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>(fp)()) std::__1::__invoke<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>((anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&) /opt/irods-externals/clang13.0.1-0/include/c++/v1/type_traits:3934:1
    #3 0xc6c323 in void std::__1::__invoke_void_return_wrapper<void, true>::__call<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>((anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&) /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/invoke.h:61:9
    #4 0xc6c323 in std::__1::__function::__alloc_func<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8, std::__1::allocator<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8>, void ()>::operator()() /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:171:16
    #5 0xc6c323 in std::__1::__function::__func<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8, std::__1::allocator<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8>, void ()>::operator()() /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:345:12
    #6 0x95fe89 in std::__1::__function::__value_func<void ()>::operator()() const /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:498:16
    #7 0x95f418 in std::__1::function<void ()>::operator()() const /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:1175:12
    #8 0x95f418 in irods::http::globals::background_task(std::__1::function<void ()>)::$_0::operator()() const /workspaces/irods_client_http_api/core/src/globals.cpp:65:5
    #9 0x95f418 in boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>::operator()() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/bind_handler.hpp:60:5
    #10 0x95f5cb in void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>, boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0> >(boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>&, boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/handler_invoke_helpers.hpp:51:3
    #11 0x95f5cb in boost::asio::detail::executor_op<boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/executor_op.hpp:70:7
    #12 0x9ae98a in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/scheduler_operation.hpp:40:5
    #13 0x9ae98a in boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/scheduler.ipp:492:12
    #14 0x9ae02c in boost::asio::detail::scheduler::run(boost::system::error_code&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/scheduler.ipp:210:10
    #15 0x9eddf8 in boost::asio::thread_pool::thread_function::operator()() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/impl/thread_pool.ipp:39:19
    #16 0x9edc93 in boost::asio::detail::posix_thread::func<boost::asio::thread_pool::thread_function>::run() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/posix_thread.hpp:86:7
    #17 0x9ad818 in boost_asio_detail_posix_thread_function /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/posix_thread.ipp:74:13
    #18 0x7dbb2a527ac2 in start_thread nptl/./nptl/pthread_create.c:442:8

Indirect leak of 247 byte(s) in 12 object(s) allocated from:
    #0 0x727997 in strdup /externals/clang13.0.1-0_src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:439:3
    #1 0x7dbb2affc0d7 in addKeyVal (/lib/libirods_common.so.4.3.2+0x1740d7)

Indirect leak of 86 byte(s) in 8 object(s) allocated from:
    #0 0x727997 in strdup /externals/clang13.0.1-0_src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:439:3
    #1 0x7dbb2affc0c2 in addKeyVal (/lib/libirods_common.so.4.3.2+0x1740c2)

Indirect leak of 36 byte(s) in 4 object(s) allocated from:
    #0 0x727997 in strdup /externals/clang13.0.1-0_src/llvm-project/compiler-rt/lib/asan/asan_interceptors.cpp:439:3
    #1 0x7dbb2affc0c2 in addKeyVal (/lib/libirods_common.so.4.3.2+0x1740c2)
    #2 0xc6c323 in decltype(static_cast<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>(fp)()) std::__1::__invoke<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>((anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&) /opt/irods-externals/clang13.0.1-0/include/c++/v1/type_traits:3934:1
    #3 0xc6c323 in void std::__1::__invoke_void_return_wrapper<void, true>::__call<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&>((anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8&) /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/invoke.h:61:9
    #4 0xc6c323 in std::__1::__function::__alloc_func<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8, std::__1::allocator<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8>, void ()>::operator()() /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:171:16
    #5 0xc6c323 in std::__1::__function::__func<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8, std::__1::allocator<(anonymous namespace)::op_register(std::__1::shared_ptr<irods::http::session>, boost::beast::http::message<true, boost::beast::http::basic_string_body<char, std::__1::char_traits<char>, std::__1::allocator<char> >, boost::beast::http::basic_fields<std::__1::allocator<char> > >&, std::__1::unordered_map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >, std::__1::hash<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::equal_to<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > >, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > > > >&)::$_8>, void ()>::operator()() /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:345:12
    #6 0x95fe89 in std::__1::__function::__value_func<void ()>::operator()() const /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:498:16
    #7 0x95f418 in std::__1::function<void ()>::operator()() const /opt/irods-externals/clang13.0.1-0/include/c++/v1/__functional/function.h:1175:12
    #8 0x95f418 in irods::http::globals::background_task(std::__1::function<void ()>)::$_0::operator()() const /workspaces/irods_client_http_api/core/src/globals.cpp:65:5
    #9 0x95f418 in boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>::operator()() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/bind_handler.hpp:60:5
    #10 0x95f5cb in void boost_asio_handler_invoke_helpers::invoke<boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>, boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0> >(boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>&, boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/handler_invoke_helpers.hpp:51:3
    #11 0x95f5cb in boost::asio::detail::executor_op<boost::asio::detail::binder0<irods::http::globals::background_task(std::__1::function<void ()>)::$_0>, std::__1::allocator<void>, boost::asio::detail::scheduler_operation>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/executor_op.hpp:70:7
    #12 0x9ae98a in boost::asio::detail::scheduler_operation::complete(void*, boost::system::error_code const&, unsigned long) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/scheduler_operation.hpp:40:5
    #13 0x9ae98a in boost::asio::detail::scheduler::do_run_one(boost::asio::detail::conditionally_enabled_mutex::scoped_lock&, boost::asio::detail::scheduler_thread_info&, boost::system::error_code const&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/scheduler.ipp:492:12
    #14 0x9ae02c in boost::asio::detail::scheduler::run(boost::system::error_code&) /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/scheduler.ipp:210:10
    #15 0x9eddf8 in boost::asio::thread_pool::thread_function::operator()() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/impl/thread_pool.ipp:39:19
    #16 0x9edc93 in boost::asio::detail::posix_thread::func<boost::asio::thread_pool::thread_function>::run() /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/posix_thread.hpp:86:7
    #17 0x9ad818 in boost_asio_detail_posix_thread_function /opt/irods-externals/boost-libcxx1.81.0-1/include/boost/asio/detail/impl/posix_thread.ipp:74:13
    #18 0x7dbb2a527ac2 in start_thread nptl/./nptl/pthread_create.c:442:8

SUMMARY: AddressSanitizer: 1009 byte(s) leaked in 32 allocation(s).
```