### PR TITLE
[#391] Add missing return to `set_log_level(...)`

### DIFF
--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -679,6 +679,7 @@ auto set_log_level(const json& _config) -> void
 
 	if (iter == std::end(_config)) {
 		spdlog::set_level(spdlog::level::info);
+		return;
 	}
 
 	const auto& lvl_string = iter->get_ref<const std::string&>();


### PR DESCRIPTION
This prevents a past the end iterator dereference.