### PR TITLE
[#412] Ensure outbound HTTP communications terminate correctly (main)

### DIFF
--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -827,6 +827,8 @@ auto load_oidc_configuration(const json& _config, json& _oi_config, json& _endpo
 		beast::http::request<beast::http::string_body> req{beast::http::verb::get, path, http_version_number};
 		req.set(beast::http::field::host, irods::http::create_host_field(url, *port));
 		req.set(beast::http::field::user_agent, irods::http::version::server_name);
+		req.keep_alive(false);
+		req.prepare_payload();
 
 		// Sends and receives response
 		auto res{tcp_stream->communicate(req)};

--- a/core/src/openid.cpp
+++ b/core/src/openid.cpp
@@ -29,6 +29,8 @@ namespace irods::http::openid
 		req.set(beast::http::field::user_agent, irods::http::version::server_name);
 		req.set(beast::http::field::content_type, "application/x-www-form-urlencoded");
 		req.set(beast::http::field::accept, "application/json");
+		req.keep_alive(false);
+		req.prepare_payload();
 
 		if (const auto secret_key{irods::http::globals::oidc_configuration().find("client_secret")};
 		    secret_key != std::end(irods::http::globals::oidc_configuration()))
@@ -214,6 +216,7 @@ namespace irods::http::openid
 		req.set(beast::http::field::host, irods::http::create_host_field(url, *port));
 		req.set(beast::http::field::user_agent, irods::http::version::server_name);
 		req.set(beast::http::field::accept, "application/json");
+		req.keep_alive(false);
 		req.prepare_payload();
 
 		// Send request and receive response


### PR DESCRIPTION
Issue quick link: #412

This PR attempts to fix hangs in disconnecting that block until some timeout is reached. The problem is that, by default, HTTP 1.1 assumes that connections will be kept alive. We add `.keep_alive(false)` to the request to close the connection.

~This PR is in draft, since the specifics of the issue are not completely clear yet.~