### PR TITLE
[#419] Remove non-standard behavior for symmetrically signed JWTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,6 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
 
                 // The secret used when validating a JWT signed with
                 // a symmetric algorithm (e.g. HS256).
-                // Used if provided, otherwise, defaults to validating
-                // with "client_secret".
                 // If provided, it MUST be base64url encoded.
                 "access_token_secret": "xxxxxxxxxxxxxxx",
 

--- a/core/src/openid.cpp
+++ b/core/src/openid.cpp
@@ -255,13 +255,6 @@ namespace irods::http::openid
 			key = jwt::base::decode<jwt::alphabet::base64url>(
 				jwt::base::pad<jwt::alphabet::base64url>(access_token_secret->get_ref<const std::string&>()));
 		}
-		// While not for access tokens, ID Tokens are signed using the client_secret.
-		// Some OpenID providers may do the same for access tokens.
-		else if (auto secret{irods::http::globals::oidc_configuration().find("client_secret")};
-		         secret != std::end(irods::http::globals::oidc_configuration()))
-		{
-			key = secret->get<std::string>();
-		}
 		else {
 			logging::warn("{}: No secret provided. Unable to use symmetric algorithms.", __func__);
 			return;


### PR DESCRIPTION
Issue quick link: #419

Remove the default of using `client_secret` for a JWT that is signed with a symmetric key.