### PR TITLE
Fix iRODS compatibility / Fix test failures / Documentation (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,14 @@ The builder image is responsible for building the iRODS HTTP API package. Before
 docker build -t irods-http-api-builder -f irods_builder.ub22.Dockerfile .
 ```
 
+The builder image defaults to installing the development packages of the minimum supported iRODS version, 4.3.2. To install a later version of the development packages, set the `irods_version` parameter. The following is an example which demonstrates building the builder with development packages for iRODS 5.0.1.
+```bash
+docker build -t irods-http-api-builder -f irods_builder.ub22.Dockerfile --build-arg 'irods_version=5.0.1-0~jammy' .
+```
+
+> [!Note]
+> Using updated iRODS packages can sometimes resolve compatibility issues. This is particularly true when the client is built against a version of iRODS which is older than the iRODS server which it is connecting to.
+
 With the builder image in hand, all that's left is to build the iRODS HTTP API project. The builder image is designed to compile code sitting on your machine. This is important because it gives you the ability to build any fork or branch of the project. **Keep in mind the [GenQuery2 API plugin](https://github.com/irods/irods_api_plugin_genquery2) is no longer supported.**
 
 Building the package requires mounting the project into the container at the appropriate location. The command you run should look similar to the one below. **Don't forget to create the directory which will hold your packages!**

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(
   irods_http_api_core
   OBJECT
   "${CMAKE_CURRENT_SOURCE_DIR}/src/common.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/compatibility.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/globals.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/multipart_form_data.cpp"

--- a/core/include/irods/private/http_api/compatibility.hpp
+++ b/core/include/irods/private/http_api/compatibility.hpp
@@ -1,6 +1,7 @@
 #ifndef IRODS_HTTP_API_COMPATIBILITY_HPP
 #define IRODS_HTTP_API_COMPATIBILITY_HPP
 
+#include <irods/group.hpp>
 #include <irods/packStruct.h>
 #include <irods/rcConnect.h>
 #include <irods/rodsDef.h>
@@ -19,6 +20,14 @@ namespace irods::http::compatibility
 		const bytesBuf_t* _inputBsBBuf,
 		void** _outStruct,
 		bytesBuf_t* _outBsBBuf) -> int;
+
+	// This is a custom implementation of add_group(), from the user administration
+	// library. It is needed to maintain backward compatibility with iRODS servers which
+	// do not support the "group" keyword - e.g. iRODS 4.3.3 and earlier.
+	auto add_group(
+		bool _irods_server_supports_group_keyword,
+		RcComm& _comm,
+		const irods::experimental::administration::group& _group) -> void;
 } // namespace irods::http::compatibility
 
 #endif // IRODS_HTTP_API_COMPATIBILITY_HPP

--- a/core/include/irods/private/http_api/compatibility.hpp
+++ b/core/include/irods/private/http_api/compatibility.hpp
@@ -1,0 +1,24 @@
+#ifndef IRODS_HTTP_API_COMPATIBILITY_HPP
+#define IRODS_HTTP_API_COMPATIBILITY_HPP
+
+#include <irods/packStruct.h>
+#include <irods/rcConnect.h>
+#include <irods/rodsDef.h>
+
+namespace irods::http::compatibility
+{
+	// A custom implementation of procApiRequest which allows the caller to
+	// control which packing instruction is used. This implementation is designed
+	// to help with compatibility issues stemming from changes in packing instructions.
+	auto procApiRequest(
+		rcComm_t* _comm,
+		int _apiNumber,
+		const char* _packingInstruction,
+		const PackingInstruction* _packingInstructionTable,
+		const void* _inputStruct,
+		const bytesBuf_t* _inputBsBBuf,
+		void** _outStruct,
+		bytesBuf_t* _outBsBBuf) -> int;
+} // namespace irods::http::compatibility
+
+#endif // IRODS_HTTP_API_COMPATIBILITY_HPP

--- a/core/src/compatibility.cpp
+++ b/core/src/compatibility.cpp
@@ -1,0 +1,160 @@
+#include "irods/private/http_api/compatibility.hpp"
+
+#include "irods/private/http_api/log.hpp"
+
+#include <irods/irods_client_api_table.hpp>
+#include <irods/irods_network_factory.hpp>
+#include <irods/irods_threads.hpp>
+#include <irods/rcGlobalExtern.h>
+#include <irods/rcMisc.h>
+#include <irods/rodsErrorTable.h>
+#include <irods/sockComm.h>
+#include <irods/sockCommNetworkInterface.hpp>
+
+namespace
+{
+	namespace logging = irods::http::log;
+
+	auto send_api_request(
+		rcComm_t* conn,
+		int apiInx,
+		const char* _packingInstruction,
+		const PackingInstruction* _packingInstructionTable,
+		const void* inputStruct,
+		const bytesBuf_t* inputBsBBuf) -> int
+	{
+		int status = 0;
+		bytesBuf_t* inputStructBBuf = nullptr;
+		bytesBuf_t* myInputStructBBuf = nullptr;
+
+		cliChkReconnAtSendStart(conn);
+
+		irods::api_entry_table& RcApiTable = irods::get_client_api_table();
+		auto itr = RcApiTable.find(apiInx);
+
+		if (itr == RcApiTable.end()) {
+			logging::error("{}: Could not find API entry matching at index [{}].", __func__, apiInx);
+			return SYS_UNMATCHED_API_NUM;
+		}
+
+		if (itr->second->inPackInstruct != nullptr) {
+			if (inputStruct == nullptr) {
+				cliChkReconnAtSendEnd(conn);
+				return USER_API_INPUT_ERR;
+			}
+			status = pack_struct(
+				inputStruct,
+				&inputStructBBuf,
+				_packingInstruction,
+				_packingInstructionTable,
+				0,
+				conn->irodsProt,
+				conn->svrVersion->relVersion);
+			if (status < 0) {
+				logging::error("{}: Packing instruction error; error_code=[{}]", __func__, status);
+				cliChkReconnAtSendEnd(conn);
+				return status;
+			}
+
+			myInputStructBBuf = inputStructBBuf;
+		}
+		else {
+			myInputStructBBuf = nullptr;
+		}
+
+		if (itr->second->inBsFlag <= 0) {
+			inputBsBBuf = nullptr;
+		}
+
+		irods::network_object_ptr net_obj;
+		irods::error ret = irods::network_factory(conn, net_obj);
+		if (!ret.ok()) {
+			freeBBuf(inputStructBBuf);
+			logging::error("{}: network_factory error: [{}], error_code=[{}]", __func__, ret.user_result(), ret.code());
+			return static_cast<int>(ret.code());
+		}
+
+		ret = sendRodsMsg(
+			net_obj, RODS_API_REQ_T, myInputStructBBuf, inputBsBBuf, nullptr, itr->second->apiNumber, conn->irodsProt);
+		if (!ret.ok()) {
+			logging::error("{}: sendRodsMsg error: [{}].", __func__, ret.code());
+			if (conn->svrVersion != nullptr && conn->svrVersion->reconnPort > 0) {
+				const auto savedStatus = static_cast<int>(ret.code());
+				conn->thread_ctx->lock->lock();
+				int status1 = cliSwitchConnect(conn);
+				logging::debug(
+					"{}: cliSwitchConnect error: [{}]; clientState=[{}], agentState=[{}]",
+					__func__,
+					status1,
+					conn->clientState,
+					conn->agentState);
+				conn->thread_ctx->lock->unlock();
+				if (status1 > 0) {
+					// Should not be here.
+					logging::info("{}: Switch connection and retry sendRodsMsg.", __func__);
+					ret = sendRodsMsg(
+						net_obj,
+						RODS_API_REQ_T,
+						myInputStructBBuf,
+						inputBsBBuf,
+						nullptr,
+						itr->second->apiNumber,
+						conn->irodsProt);
+					if (!ret.ok()) {
+						logging::error("{}: {}; error_code=[{}].", __func__, ret.user_result(), ret.code());
+					}
+					else {
+						status = savedStatus;
+					}
+				} // if status1 > 0
+			} // if svrVersion != nullptr ...
+		}
+		else {
+			// be sure to pass along the return code from the
+			// plugin call
+			status = static_cast<int>(ret.code());
+		}
+
+		freeBBuf(inputStructBBuf);
+
+		return status;
+	}
+} // anonymous namespace
+
+namespace irods::http::compatibility
+{
+	auto procApiRequest(
+		rcComm_t* _comm,
+		int _apiNumber,
+		const char* _packingInstruction,
+		const PackingInstruction* _packingInstructionTable,
+		const void* _inputStruct,
+		const bytesBuf_t* _inputBsBBuf,
+		void** _outStruct,
+		bytesBuf_t* _outBsBBuf) -> int
+	{
+		if (!_comm) {
+			return USER__NULL_INPUT_ERR;
+		}
+
+		freeRError(_comm->rError);
+		_comm->rError = nullptr;
+
+		const int apiInx = apiTableLookup(_apiNumber);
+
+		if (apiInx < 0) {
+			return apiInx;
+		}
+
+		if (const auto ec = send_api_request(
+				_comm, apiInx, _packingInstruction, _packingInstructionTable, _inputStruct, _inputBsBBuf);
+		    ec < 0)
+		{
+			return ec;
+		}
+
+		_comm->apiInx = apiInx;
+
+		return readAndProcApiReply(_comm, apiInx, _outStruct, _outBsBBuf);
+	} // procApiRequest
+} // namespace irods::http::compatibility

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -1029,6 +1029,7 @@ auto main(int _argc, char* _argv[]) -> int
 		else {
 			logging::info("No OIDC configuration detected, running without OIDC features.");
 		}
+
 		// TODO For LONG running tasks, see the following:
 		//
 		//   - https://stackoverflow.com/questions/17648725/long-running-blocking-operations-in-boost-asio-handlers

--- a/irods_builder.el8.Dockerfile
+++ b/irods_builder.el8.Dockerfile
@@ -38,6 +38,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf config-manager -y --set-enabled powertools && \
     rm -rf /tmp/*
 
+# The version of the iRODS packages to build against.
 ARG irods_version=4.3.2-0.el8
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     --mount=type=cache,target=/var/cache/yum,sharing=locked \

--- a/irods_builder.el9.Dockerfile
+++ b/irods_builder.el9.Dockerfile
@@ -38,6 +38,7 @@ RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     dnf config-manager -y --set-enabled crb && \
     rm -rf /tmp/*
 
+# The version of the iRODS packages to build against.
 ARG irods_version=4.3.2-0.el9
 RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked \
     --mount=type=cache,target=/var/cache/yum,sharing=locked \

--- a/irods_builder.ub22.Dockerfile
+++ b/irods_builder.ub22.Dockerfile
@@ -31,6 +31,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
     echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list
 
+# The version of the iRODS packages to build against.
 ARG irods_version=4.3.2-0~jammy
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -4152,9 +4152,9 @@ class test_zones_endpoint(unittest.TestCase):
         self.assertEqual(result['irods_response']['status_code'], 0)
 
         zone_report = result['zone_report']
-        self.assertIn('schema_version', zone_report)
         self.assertIn('zones', zone_report)
         self.assertGreaterEqual(len(zone_report['zones']), 1)
+        self.assertIn('servers', zone_report['zones'][0])
 
     def test_adding_removing_and_modifying_zones(self):
         headers = {'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -2328,65 +2328,65 @@ class test_data_objects_endpoint(unittest.TestCase):
 
     def test_modifying_replica_properties(self):
         headers = {'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}
-
-        # Create a data object.
         data_object = os.path.join('/', self.zone_name, 'home', self.rodsadmin_username, 'modrepl.txt')
-        r = requests.post(self.url_endpoint, headers=headers, data={
-            'op': 'touch',
-            'lpath': data_object
-        })
-        self.logger.debug(r.content)
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
-        # Show the replica is currently marked as good and has a size of 0.
-        r = requests.get(f'{self.url_base}/query', headers=headers, params={
-            'op': 'execute_genquery',
-            'query': f"select DATA_REPL_STATUS, DATA_SIZE where COLL_NAME = '{os.path.dirname(data_object)}' and DATA_NAME = '{os.path.basename(data_object)}'"
-        })
-        self.logger.debug(r.content)
-        self.assertEqual(r.status_code, 200)
+        try:
+            # Create a data object.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'touch',
+                'lpath': data_object
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
-        result = r.json()
-        self.assertEqual(result['irods_response']['status_code'], 0)
-        self.assertEqual(result['rows'][0][0], '1')
-        self.assertEqual(result['rows'][0][1], '0')
+            # Show the replica is currently marked as good and has a size of 0.
+            r = requests.get(f'{self.url_base}/query', headers=headers, params={
+                'op': 'execute_genquery',
+                'query': f"select DATA_REPL_STATUS, DATA_SIZE where COLL_NAME = '{os.path.dirname(data_object)}' and DATA_NAME = '{os.path.basename(data_object)}'"
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
 
-        # Change the replica's status and data size using the modify_replica operation.
-        r = requests.post(self.url_endpoint, headers=headers, data={
-            'op': 'modify_replica',
-            'lpath': data_object,
-            'replica-number': 0,
-            'new-data-replica-status': 0,
-            'new-data-size': 15
-        })
-        self.logger.debug(r.content)
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['status_code'], 0)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['rows'][0][0], '1')
+            self.assertEqual(result['rows'][0][1], '0')
 
-        # Show the replica's status and size has changed in the catalog.
-        r = requests.get(f'{self.url_base}/query', headers=headers, params={
-            'op': 'execute_genquery',
-            'query': f"select DATA_REPL_STATUS, DATA_SIZE where COLL_NAME = '{os.path.dirname(data_object)}' and DATA_NAME = '{os.path.basename(data_object)}'"
-        })
-        self.logger.debug(r.content)
-        self.assertEqual(r.status_code, 200)
+            # Change the replica's status and data size using the modify_replica operation.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'modify_replica',
+                'lpath': data_object,
+                'replica-number': 0,
+                'new-data-replica-status': 0,
+                'new-data-size': 15
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
 
-        result = r.json()
-        self.assertEqual(result['irods_response']['status_code'], 0)
-        self.assertEqual(result['rows'][0][0], '0')
-        self.assertEqual(result['rows'][0][1], '15')
+            # Show the replica's status and size has changed in the catalog.
+            r = requests.get(f'{self.url_base}/query', headers=headers, params={
+                'op': 'execute_genquery',
+                'query': f"select DATA_REPL_STATUS, DATA_SIZE where COLL_NAME = '{os.path.dirname(data_object)}' and DATA_NAME = '{os.path.basename(data_object)}'"
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
 
-        # Remove the data object.
-        r = requests.post(self.url_endpoint, headers=headers, data={
-            'op': 'remove',
-            'lpath': data_object,
-            'catalog-only': 0,
-            'no-trash': 1
-        })
-        self.logger.debug(r.content)
-        self.assertEqual(r.status_code, 200)
-        self.assertEqual(r.json()['irods_response']['status_code'], 0)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['rows'][0][0], '0')
+            self.assertEqual(result['rows'][0][1], '15')
+
+        finally:
+            # Remove the data object.
+            r = requests.post(self.url_endpoint, headers=headers, data={
+                'op': 'remove',
+                'lpath': data_object,
+                'catalog-only': 0,
+                'no-trash': 1
+            })
+            self.logger.debug(r.content)
 
     def test_remove_operation_returns_an_error_when_catalog_only_is_1_and_no_trash_is_1(self):
         r = requests.post(self.url_endpoint, headers={'Authorization': 'Bearer ' + self.rodsadmin_bearer_token}, data={


### PR DESCRIPTION
Confirmed the non-OIDC tests pass for the following configurations:
- HTTP API compiled against iRODS 5.0.1
  - Connected to iRODS 5.0.1 server
  - Connected to iRODS 4.3.4 server
  - Connected to iRODS 4.3.3 server
- HTTP API compiled against iRODS 4.3.2
  - Connected to iRODS 5.0.1 server
  - Connected to iRODS 4.3.4 server
  - Connected to iRODS 4.3.3 server