### PR TITLE
[#443] Set default TLS cert directory (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
 
                 // The path to the TLS certificates directory used to establish
                 // secure connections between the HTTP API and the OpenID provider.
-                // Typically, this should point to a standard certificate directory
-                // such as "/etc/ssl/cert".
+                // This should not be set unless your TLS certificates directory is
+                // not a standard certificate directory such as "/etc/ssl/cert".
                 "tls_certificates_directory": "/path/to/certs"
             }
         },

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -269,7 +269,6 @@ constexpr auto default_jsonschema() -> std::string_view
                                 "provider_url",
                                 "client_id",
                                 "require_aud_member_from_introspection_endpoint",
-                                "tls_certificates_directory",
                                 "user_mapping",
                                 "client_secret"
                             ]

--- a/core/src/transport.cpp
+++ b/core/src/transport.cpp
@@ -134,11 +134,13 @@ namespace irods::http
 	{
 		boost::asio::ssl::context ctx{boost::asio::ssl::context::tlsv12_client};
 		const auto config{irods::http::globals::oidc_configuration()};
+		ctx.set_default_verify_paths();
 
-		const std::string& cert_path{config.at("tls_certificates_directory").get_ref<const std::string&>()};
-		ctx.add_verify_path(cert_path);
+		if (const auto cert_path{config.find("tls_certificates_directory")}; cert_path != std::end(config)) {
+		  ctx.add_verify_path(cert_path->get_ref<const std::string&>());
+		}
+
 		ctx.set_verify_mode(boost::asio::ssl::verify_peer);
-
 		return ctx;
 	}
 


### PR DESCRIPTION
Issue quick link: #443 

This PR attempts to automatically set the TLS certificate directory to the default for the system. Additionally, `tls_certificates_directory` becomes an optional custom certificate directory which may point to a non-default location for additional TLS certificates.

---

Before pulling out of draft:
- [ ] Format code.
- [ ] Test setting `tls_certificates_directory` (the default certs should still be included).