### PR TITLE
[#448] Make access token validation method selectable (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,15 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
                 // times out, requiring another attempt at authentication.
                 "state_timeout_in_seconds": 600,
 
+                // The desired method with which to validate OIDC access tokens.
+                // The two methods supported are "local_validation" and
+                // "introspection".
+                //
+                // The following values are supported:
+                // - local_validation: Validate JWT access tokens according to RFC 9086.
+                // - introspection: Validate access tokens according to RFC 7662.
+                "access_token_validation_method": "local_validation",
+
                 // Defines relevant information related to the User Mapping plugin system.
                 // Allows for the selection and configuration of the plugin.
                 "user_mapping": {

--- a/core/src/common.cpp
+++ b/core/src/common.cpp
@@ -339,25 +339,30 @@ namespace irods::http
 				config.contains(nlohmann::json::json_pointer{"/http_server/authentication/openid_connect"})};
 			if (oidc_conf_exists) {
 				nlohmann::json json_res;
+				const auto& validation_method{irods::http::globals::oidc_configuration()
+				                                  .at("access_token_validation_method")
+				                                  .get_ref<const std::string&>()};
 
 				// Try parsing token as JWT Access Token
-				try {
-					auto token{jwt::decode<jwt::traits::nlohmann_json>(bearer_token)};
-					auto possible_json_res{openid::validate_using_local_validation(token)};
+				if (validation_method == "local_validation") {
+					try {
+						auto token{jwt::decode<jwt::traits::nlohmann_json>(bearer_token)};
+						auto possible_json_res{openid::validate_using_local_validation(token)};
 
-					if (possible_json_res) {
-						json_res = *possible_json_res;
+						if (possible_json_res) {
+							json_res = *possible_json_res;
+						}
+					}
+					// Parsing of the token failed, this is not a JWT access token
+					catch (const std::exception& e) {
+						logging::debug("{}: {}", __func__, e.what());
 					}
 				}
-				// Parsing of the token failed, this is not a JWT access token
-				catch (const std::exception& e) {
-					logging::debug("{}: {}", __func__, e.what());
-				}
 
-				// Use introspection endpoint if it exists and local validation fails
+				// Use introspection endpoint if it exists
 				static const auto introspection_endpoint_exists{
 					irods::http::globals::oidc_endpoint_configuration().contains("introspection_endpoint")};
-				if (json_res.empty() && introspection_endpoint_exists) {
+				if (introspection_endpoint_exists && validation_method == "introspection") {
 					auto possible_json_res{openid::validate_using_introspection_endpoint(bearer_token)};
 					if (possible_json_res) {
 						json_res = *possible_json_res;

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -241,6 +241,9 @@ constexpr auto default_jsonschema() -> std::string_view
                                 "access_token_secret": {
                                     "type": "string"
                                 },
+                                "access_token_validation_method": {
+                                    "enum": ["local_validation", "introspection"]
+                                },
                                 "require_aud_member_from_introspection_endpoint": {
                                     "type": "boolean"
                                 },
@@ -271,7 +274,8 @@ constexpr auto default_jsonschema() -> std::string_view
                                 "require_aud_member_from_introspection_endpoint",
                                 "tls_certificates_directory",
                                 "user_mapping",
-                                "client_secret"
+                                "client_secret",
+                                "access_token_validation_method"
                             ]
                         }
                     },
@@ -496,6 +500,7 @@ auto print_configuration_template() -> void
                 "client_id": "<string>",
                 "client_secret": "<string>",
                 "require_aud_member_from_introspection_endpoint": false,
+                "access_token_validation_method": "local_validation",
                 "user_mapping": {{
                     "plugin_path": "<string>",
                     "configuration": {{


### PR DESCRIPTION
Issue quick link: #448

This PR introduces a new schema item to select the desired access token validation method. The selected method will be the only method that runs until the configuration is changed and the server is restarted.

If you have suggestions for the schema item name and names for the enums, they would be appreciated.

---

Before getting out of draft:

- [x] Ensure only one access token validation method is executed at a time, and that the method executed is the one selected.