### PR TITLE
[#476] Provide local implementation for group permission expansion bug (main)

### DIFF
--- a/endpoints/data_objects/src/main.cpp
+++ b/endpoints/data_objects/src/main.cpp
@@ -17,19 +17,23 @@
 #include <irods/dataObjTrim.h>
 #include <irods/dataObjUnlink.h>
 #include <irods/filesystem.hpp>
+#include <irods/filesystem/path.hpp>
 #include <irods/filesystem/path_utilities.hpp>
 #include <irods/irods_at_scope_exit.hpp>
 #include <irods/irods_exception.hpp>
 #include <irods/irods_version.h>
 #include <irods/key_value_proxy.hpp>
 #include <irods/modDataObjMeta.h>
+#include <irods/objStat.h>
 #include <irods/packStruct.h>
 #include <irods/phyPathReg.h>
+#include <irods/query_builder.hpp>
 #include <irods/rcMisc.h>
 #include <irods/replica_truncate.h>
 #include <irods/rodsErrorTable.h>
 #include <irods/rodsKeyWdDef.h>
 #include <irods/rodsPackInstruct.h>
+#include <irods/system_error.hpp>
 #include <irods/ticketAdmin.h>
 #include <irods/touch.h>
 #include <irods/version.hpp>
@@ -51,6 +55,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstdint>
 #include <mutex>
 #include <span>
 #include <shared_mutex>
@@ -1893,6 +1898,8 @@ namespace
 					}
 				}
 
+				json perms;
+#if IRODS_VERSION_INTEGER >= 5001000
 				const auto status = fs::client::status(conn, lpath_iter->second);
 
 				if (!fs::client::is_data_object(status)) {
@@ -1901,7 +1908,6 @@ namespace
 					return _sess_ptr->send(std::move(res));
 				}
 
-				json perms;
 				for (auto&& ep : status.permissions()) {
 					perms.push_back(json{
 						{"name", ep.name},
@@ -1910,11 +1916,61 @@ namespace
 						{"perm", irods::to_permission_string(ep.prms)},
 					});
 				}
+#else
+				// This preprocessor branch fixes a group permissions expansion bug in the iRODS
+				// filesystem library. The bug exists in versions of the development library prior
+				// to iRODS 5.1.0. For more information, see GitHub issue irods/irods#8912.
+
+				DataObjInp input{};
+				lpath_iter->second.copy(input.objPath, sizeof(DataObjInp::objPath) - 1);
+
+				rodsObjStat_t* output{};
+				std::int64_t data_id = -1;
+
+				if (const auto ec = rcObjStat(static_cast<RcComm*>(conn), &input, &output); ec == DATA_OBJ_T) {
+					const irods::at_scope_exit free_output{[output] { freeRodsObjStat(output); }};
+
+					try {
+						data_id = std::stoll(output->dataId);
+					}
+					catch (...) {
+						throw fs::filesystem_error{
+							"stat error: cannot convert string to integer",
+							lpath_iter->second,
+							irods::experimental::make_error_code(SYS_INTERNAL_ERR)};
+					}
+				}
+				else {
+					res.body() = json{{"irods_response", {{"status_code", NOT_A_DATA_OBJECT}}}}.dump();
+					res.prepare_payload();
+					return _sess_ptr->send(std::move(res));
+				}
+
+				irods::experimental::query_builder qb;
+
+				if (const auto zone = fs::zone_name(lpath_iter->second); zone) {
+					qb.zone_hint(*zone);
+				}
+
+				const auto query_string = fmt::format(
+					"select USER_NAME, USER_ZONE, USER_TYPE, DATA_ACCESS_NAME "
+					"where DATA_ACCESS_DATA_ID = '{}' and DATA_TOKEN_NAMESPACE = 'access_type'",
+					data_id);
+
+				for (const auto& row : qb.build<RcComm>(conn, query_string)) {
+					perms.push_back(json{
+						{"name", row[0]},
+						{"zone", row[1]},
+						{"type", row[2]},
+						{"perm", row[3]},
+					});
+				}
+#endif // IRODS_VERSION_INTEGER >= 5001000
 
 				// clang-format off
 				res.body() = json{
 					{"irods_response", {{"status_code", 0}}},
-					{"type", irods::to_object_type_string(status.type())},
+					{"type", "data_object"},
 					{"permissions", perms},
 					{"size", fs::client::data_object_size(conn, lpath_iter->second)},
 					{"checksum", fs::client::data_object_checksum(conn, lpath_iter->second)},
@@ -1923,7 +1979,7 @@ namespace
 				// clang-format on
 			}
 			catch (const fs::filesystem_error& e) {
-				logging::error(*_sess_ptr, "{}: {}", fn, e.what());
+				logging::error(*_sess_ptr, "{}: {}; lpath=[{}]", fn, e.what(), e.path1().c_str());
 				res.body() =
 					json{{"irods_response", {{"status_code", e.code().value()}, {"status_message", e.what()}}}}.dump();
 			}

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -3841,6 +3841,183 @@ class test_data_objects_endpoint(unittest.TestCase):
             })
             self.logger.debug(r.content)
 
+    def test_stat_does_not_expand_group_permissions(self):
+        rodsadmin_headers = {'Authorization': f'Bearer {self.rodsadmin_bearer_token}'}
+        rodsuser_headers = {'Authorization': f'Bearer {self.rodsuser_bearer_token}'}
+
+        users = ['rodsuser1_issue_476', 'rodsuser2_issue_476']
+        groups = ['rodsgroup1_issue_476', 'rodsgroup2_issue_476']
+
+        data_object = f'/{self.zone_name}/home/{self.rodsuser_username}/data_object.txt'
+        group_permission = 'read_object'
+
+        try:
+            # Create two rodsusers.
+            for user in users:
+                r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                    'op': 'create_user',
+                    'name': user,
+                    'zone': self.zone_name
+                })
+                self.logger.debug(r.content)
+                self.assertEqual(r.status_code, 200)
+                self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Create two groups.
+            for group in groups:
+                r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                    'op': 'create_group',
+                    'name': group
+                })
+                self.logger.debug(r.content)
+                self.assertEqual(r.status_code, 200)
+                self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Add one user to each group.
+            r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                'op': 'add_to_group',
+                'group': groups[0],
+                'user': users[1],
+                'zone': self.zone_name
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            r = requests.get(f'{self.url_base}/users-groups', headers=rodsadmin_headers, params={
+                'op': 'is_member_of_group',
+                'group': groups[0],
+                'user': users[1],
+                'zone': self.zone_name
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['is_member'], True)
+
+            r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                'op': 'add_to_group',
+                'group': groups[1],
+                'user': users[0],
+                'zone': self.zone_name
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            r = requests.get(f'{self.url_base}/users-groups', headers=rodsadmin_headers, params={
+                'op': 'is_member_of_group',
+                'group': groups[1],
+                'user': users[0],
+                'zone': self.zone_name
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['is_member'], True)
+
+            # Create a data object and adjust the permissions such that only members
+            # of the groups can access it.
+            r = requests.post(self.url_endpoint, headers=rodsuser_headers, data={
+                'op': 'touch',
+                'lpath': data_object
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            for group in groups:
+                r = requests.post(self.url_endpoint, headers=rodsuser_headers, data={
+                    'op': 'set_permission',
+                    'lpath': data_object,
+                    'entity-name': group,
+                    'permission': group_permission
+                })
+                self.logger.debug(r.content)
+                self.assertEqual(r.status_code, 200)
+                self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            r = requests.post(self.url_endpoint, headers=rodsuser_headers, data={
+                'op': 'set_permission',
+                'lpath': data_object,
+                'entity-name': self.rodsuser_username,
+                'permission': 'null'
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Show that retrieval of the permissions for groups are not expanded.
+            r = requests.get(self.url_endpoint, headers=rodsadmin_headers, params={
+                'op': 'stat',
+                'lpath': data_object
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertIn('permissions', result)
+            self.assertEqual(len(result['permissions']), 2)
+            self.assertIn({'name': groups[0], 'zone': self.zone_name, 'type': 'rodsgroup', 'perm': group_permission}, result['permissions'])
+            self.assertIn({'name': groups[1], 'zone': self.zone_name, 'type': 'rodsgroup', 'perm': group_permission}, result['permissions'])
+
+        finally:
+            # Grant the original owner of the data object own permissions so that
+            # they can remove the data object.
+            r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                'op': 'set_permission',
+                'lpath': data_object,
+                'entity-name': self.rodsuser_username,
+                'permission': 'own',
+                'admin': 1
+            })
+            self.logger.debug(r.content)
+
+            # Remove the data object.
+            r = requests.post(self.url_endpoint, headers=rodsuser_headers, data={
+                'op': 'remove',
+                'lpath': data_object,
+                'catalog-only': 0,
+                'no-trash': 1
+            })
+            self.logger.debug(r.content)
+
+            # Remove user from group.
+            r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                'op': 'remove_from_group',
+                'group': groups[0],
+                'user': users[1],
+                'zone': self.zone_name
+            })
+            self.logger.debug(r.content)
+
+            r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                'op': 'remove_from_group',
+                'group': groups[1],
+                'user': users[0],
+                'zone': self.zone_name
+            })
+            self.logger.debug(r.content)
+
+            # Remove users.
+            for user in users:
+                r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                    'op': 'remove_user',
+                    'name': user,
+                    'zone': self.zone_name
+                })
+                self.logger.debug(r.content)
+
+            # Remove groups.
+            for group in groups:
+                r = requests.post(f'{self.url_base}/users-groups', headers=rodsadmin_headers, data={
+                    'op': 'remove_group',
+                    'name': group
+                })
+                self.logger.debug(r.content)
+
 class test_information_endpoint(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
The test is a port of https://github.com/irods/irods/commit/b546df9cb7bb2d7a5c7c94203d61af16fe32b84b.

I've confirmed that compiling this PR against a pre-release 5.1.0 dev package resolves the problem.

I now have to compile the HTTP API against a released version of the dev package (e.g. 4.3.5) and show that the test traps the bug.

The current solution is pretty small, but it results in two calls to `rcObjStat`. So, not great. I can change the implementation such that only one call to `rcObjStat` is made. That would result in more lines of code being added.