### PR TITLE
[#332] Cache client IP address for logging (main)

### DIFF
--- a/core/include/irods/private/http_api/session.hpp
+++ b/core/include/irods/private/http_api/session.hpp
@@ -8,6 +8,8 @@
 
 #include <memory>
 #include <optional>
+#include <string>
+#include <string_view>
 
 namespace irods::http
 {
@@ -20,7 +22,7 @@ namespace irods::http
 			int _max_body_size,
 			int _timeout_in_seconds);
 
-		auto ip() const -> std::string;
+		auto ip() const -> std::string_view;
 
 		auto run() -> void;
 
@@ -73,6 +75,7 @@ namespace irods::http
 		std::optional<boost::beast::http::request_parser<boost::beast::http::string_body>> parser_;
 		std::shared_ptr<void> res_; // TODO Probably doesn't need to be a shared_ptr anymore. The session owns it and is
 		                            // available for the lifetime of the request.
+		std::string ip_;
 		const request_handler_map_type* req_handlers_;
 		int max_body_size_;
 		int timeout_in_secs_;

--- a/core/include/irods/private/http_api/session.hpp
+++ b/core/include/irods/private/http_api/session.hpp
@@ -74,8 +74,8 @@ namespace irods::http
 		std::shared_ptr<void> res_; // TODO Probably doesn't need to be a shared_ptr anymore. The session owns it and is
 		                            // available for the lifetime of the request.
 		const request_handler_map_type* req_handlers_;
-		const int max_body_size_;
-		const int timeout_in_secs_;
+		int max_body_size_;
+		int timeout_in_secs_;
 	}; // class session
 } // namespace irods::http
 

--- a/core/src/session.cpp
+++ b/core/src/session.cpp
@@ -36,11 +36,23 @@ namespace irods::http
 		, max_body_size_{_max_body_size}
 		, timeout_in_secs_{_timeout_in_seconds}
 	{
+		// Cache the IP address of the client. This was motivated by a situation
+		// in which the server would crash when retrieving the client IP address from
+		// an invalid socket, for logging purposes.
+		boost::system::error_code ec;
+		if (const auto ep = stream_.socket().remote_endpoint(ec); ec) {
+			namespace logging = irods::http::log;
+			logging::info("{}: Could not retrieve client IP address from socket.", __func__);
+			ip_ = "?";
+		}
+		else {
+			ip_ = ep.address().to_string();
+		}
 	} // session (constructor)
 
-	auto session::ip() const -> std::string
+	auto session::ip() const -> std::string_view
 	{
-		return stream_.socket().remote_endpoint().address().to_string();
+		return ip_;
 	} // ip
 
 	// Start the asynchronous operation


### PR DESCRIPTION
This PR addresses a bug specific to the use of curl. I have not added a test because I don't want to create a dependency on the curl binary.

To help guard against the removal of the cached IP address, I've added a comment explaining the situation.