### PR TITLE
[#470] Allow administrators to change ips display name (main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ Notice how some of the configuration values are wrapped in angle brackets (e.g. 
 
     // Defines iRODS connection information.
     "irods_client": {
+        // The string which is sent to the iRODS server to help identify connections
+        // established by the HTTP API.
+        "name": "irods_http_api",
+
         // The hostname or IP of the target iRODS server.
         "host": "<string>",
 

--- a/core/src/main.cpp
+++ b/core/src/main.cpp
@@ -343,6 +343,11 @@ constexpr auto default_jsonschema() -> std::string_view
         "irods_client": {
             "type": "object",
             "properties": {
+                "name": {
+                    "type": "string",
+                    "pattern": "[^\\s]",
+                    "maxLength": 255
+                },
                 "host": {
                     "type": "string"
                 },
@@ -525,6 +530,8 @@ auto print_configuration_template() -> void
     }},
 
     "irods_client": {{
+        "name": "irods_http_api",
+
         "host": "<string>",
         "port": 1247,
         "zone": "<string>",
@@ -658,6 +665,12 @@ auto is_valid_configuration(const std::string& _schema_path, const std::string& 
 
 	return false;
 } // is_valid_configuration
+
+auto set_ips_display_name(const json& _config) -> void
+{
+	const auto name = _config.value(json::json_pointer{"/irods_client/name"}, "irods_http_api");
+	set_ips_display_name(name.c_str());
+} // set_ips_display_name
 
 auto set_log_level(const json& _config) -> void
 {
@@ -952,8 +965,6 @@ auto main(int _argc, char* _argv[]) -> int
 	po::positional_options_description pod;
 	pod.add("config-file", 1);
 
-	set_ips_display_name("irods_http_api");
-
 	try {
 		po::variables_map vm;
 		po::store(po::command_line_parser(_argc, _argv).options(opts_desc).positional(pod).run(), vm);
@@ -1000,6 +1011,8 @@ auto main(int _argc, char* _argv[]) -> int
 		}();
 
 		irods::http::globals::set_configuration(config);
+
+		set_ips_display_name(config);
 
 		{
 			const auto schema_file = (vm.count("jsonschema-file") > 0) ? vm["jsonschema-file"].as<std::string>() : "";


### PR DESCRIPTION
- Confirmed `ips` reflects the name defined by the new optional `name` config property
- Confirmed that if `name` is not defined, the HTTP API uses the default name and `ips` reports that name
- Empty strings and strings containing only whitespace are disallowed