### PR TITLE
[#482,#489] parallel_write_init: Fix handling of stream-count (main)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1012,7 +1012,7 @@ curl http://localhost:<port>/irods-http-api/<version>/data-objects \
     --data-urlencode 'truncate=<integer>' \ # 0 or 1. Defaults to 1. Truncates the data object before writing. Optional.
     --data-urlencode 'append=<integer>' \ # 0 or 1. Defaults to 0. Appends the bytes to the data object. Optional.
     --data-urlencode 'ticket=<string>' \ # The ticket to enable for all streams. Optional.
-    --data-urlencode 'stream-count=<integer>' # Number of streams to open.
+    --data-urlencode 'stream-count=<integer>' # Number of streams to open. Must be greater than or equal to 1.
 ```
 
 `resource` and `replica-number` are mutually exclusive parameters. The behavior of the operation is unspecified if both parameters are provided.

--- a/endpoints/data_objects/src/main.cpp
+++ b/endpoints/data_objects/src/main.cpp
@@ -1345,6 +1345,17 @@ namespace
 				}
 
 				const auto stream_count = std::stoi(stream_count_iter->second);
+				if (stream_count < 1) {
+					logging::error(
+						*_sess_ptr,
+						"{}: Argument for [stream-count] parameter is less than 1.",
+						fn,
+						stream_count_iter->second);
+					res.result(http::status::bad_request);
+					res.prepare_payload();
+					return _sess_ptr->send(std::move(res));
+				}
+
 				if (stream_count > irods::http::globals::configuration()
 				                       .at(json::json_pointer{"/irods_client/max_number_of_parallel_write_streams"})
 				                       .get<int>())

--- a/endpoints/data_objects/src/main.cpp
+++ b/endpoints/data_objects/src/main.cpp
@@ -1413,9 +1413,10 @@ namespace
 						first_stream.replica_number().value,
 						first_stream.leaf_resource_name().value);
 
-					// Open secondary streams using the first stream as a base.
+					// Open "stream_count-1" secondary streams, using the primary stream as a base.
+					// Starting the loop at 1 accounts for the primary stream and honors the requirement.
 					logging::trace(*_sess_ptr, "{}: Opening secondary output streams to [{}].", fn, lpath_iter->second);
-					for (int i = 0; i < stream_count; ++i) {
+					for (int i = 1; i < stream_count; ++i) {
 						pw_streams.emplace_back(std::make_shared<parallel_write_stream>(
 							client_info.username,
 							lpath_iter->second,

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -3316,6 +3316,25 @@ class test_data_objects_endpoint(unittest.TestCase):
         self.assertEqual(r.status_code, 200)
         self.assertEqual(r.json()['irods_response']['status_code'], irods_error_codes.INVALID_HANDLE)
 
+    def test_parallel_write_init_operation_returns_an_error_when_stream_count_is_less_than_one(self):
+        headers = {'Authorization': 'Bearer ' + self.rodsuser_bearer_token}
+
+        r = requests.post(self.url_endpoint, headers=headers, data={
+            'op': 'parallel_write_init',
+            'lpath': '/does/not/matter',
+            'stream-count': 0
+        })
+        self.logger.debug(r.content)
+        self.assertEqual(r.status_code, 400)
+
+        r = requests.post(self.url_endpoint, headers=headers, data={
+            'op': 'parallel_write_init',
+            'lpath': '/does/not/matter',
+            'stream-count': -1
+        })
+        self.logger.debug(r.content)
+        self.assertEqual(r.status_code, 400)
+
     def test_resizing_replicas(self):
         rodsuser_headers = {'Authorization': f'Bearer {self.rodsuser_bearer_token}'}
         rodsadmin_headers = {'Authorization': f'Bearer {self.rodsadmin_bearer_token}'}


### PR DESCRIPTION
- The new test fails when the fix isn't included
- The new test passes when the fix is included
- All core tests pass