### PR TITLE
[#473] Add `parent_context` to resource stat output (main)

### DIFF
--- a/API.md
+++ b/API.md
@@ -1611,7 +1611,7 @@ curl http://localhost:<port>/irods-http-api/<version>/resources \
     --data-urlencode 'op=add_child' \
     --data-urlencode 'parent-name=<string>' \
     --data-urlencode 'child-name=<string>' \
-    --data-urlencode 'context=<string>' # Additional information for the zone. Optional.
+    --data-urlencode 'context=<string>' # Information for the parent to help in managing the child. Optional.
 ```
 
 #### Response

--- a/API.md
+++ b/API.md
@@ -1730,6 +1730,7 @@ If an HTTP status code of 200 is returned, the body of the response will contain
         "vault_path": "string",
         "status": "string",
         "context": "string",
+        "parent_context": "string",
         "comments": "string",
         "information": "string",
         "free_space": "string",

--- a/endpoints/resources/src/main.cpp
+++ b/endpoints/resources/src/main.cpp
@@ -9,6 +9,7 @@
 
 #include <irods/generalAdmin.h>
 #include <irods/irods_exception.hpp>
+#include <irods/library_features.h>
 #include <irods/query_builder.hpp>
 #include <irods/resource_administration.hpp>
 #include <irods/rodsErrorTable.h>
@@ -569,7 +570,7 @@ namespace
 						"RESC_LOC, RESC_VAULT_PATH, RESC_STATUS, "
 						"RESC_CONTEXT, RESC_COMMENT, RESC_INFO, "
 						"RESC_FREE_SPACE, RESC_FREE_SPACE_TIME, "
-						"RESC_PARENT, RESC_CREATE_TIME, RESC_MODIFY_TIME "
+						"RESC_PARENT, RESC_CREATE_TIME, RESC_MODIFY_TIME, RESC_PARENT_CONTEXT "
 						"where RESC_NAME = '{}'",
 						name_iter->second);
 
@@ -593,7 +594,8 @@ namespace
 							{"parent_id", row[11]},
 							{"created", std::stoull(row[12])},
 							{"last_modified", std::stoull(row[13])},
-							{"last_modified_millis", 0}
+							{"last_modified_millis", 0},
+							{"parent_context", row[14]},
 						};
 						// clang-format on
 
@@ -610,10 +612,22 @@ namespace
 					// for the resource status. Therefore, the HTTP API uses GenQuery to retrieve the status
 					// value set by the admin.
 					std::string status;
-					const auto gql = fmt::format("select RESC_STATUS where RESC_NAME = '{}'", name_iter->second);
-					for (auto&& row : irods::experimental::query_builder{}.build<RcComm>(conn, gql)) {
+#ifdef IRODS_LIBRARY_FEATURE_RESOURCE_ADMINISTRATION
+					const auto query_str = fmt::format("select RESC_STATUS where RESC_NAME = '{}'", name_iter->second);
+					for (auto&& row : irods::experimental::query_builder{}.build<RcComm>(conn, query_str)) {
 						status = std::move(row[0]);
 					}
+#else
+					// The resource administration library provided by the iRODS development package does not
+					// expose the parent context string. Use GenQuery to retrieve it.
+					std::string parent_context;
+					const auto query_str = fmt::format(
+						"select RESC_STATUS, RESC_PARENT_CONTEXT where RESC_NAME = '{}'", name_iter->second);
+					for (auto&& row : irods::experimental::query_builder{}.build<RcComm>(conn, query_str)) {
+						status = std::move(row[0]);
+						parent_context = std::move(row[1]);
+					}
+#endif // IRODS_LIBRARY_FEATURE_RESOURCE_ADMINISTRATION
 
 					// clang-format off
 					info = {
@@ -632,7 +646,12 @@ namespace
 						{"parent_id", resc->parent_id()},
 						{"created", resc->created().time_since_epoch().count()},
 						{"last_modified", resc->last_modified().time_since_epoch().count()},
-						{"last_modified_millis", resc->last_modified_millis().count()}
+						{"last_modified_millis", resc->last_modified_millis().count()},
+#ifdef IRODS_LIBRARY_FEATURE_RESOURCE_ADMINISTRATION
+						{"parent_context", resc->parent_context_string()},
+#else
+						{"parent_context", parent_context},
+#endif // IRODS_LIBRARY_FEATURE_RESOURCE_ADMINISTRATION
 					};
 					// clang-format on
 				}

--- a/test/test_irods_http_api.py
+++ b/test/test_irods_http_api.py
@@ -4766,6 +4766,107 @@ class test_resources_endpoint(unittest.TestCase):
     def test_server_reports_error_when_op_is_not_supported(self):
         do_test_server_reports_error_when_op_is_not_supported(self)
 
+    def test_stat_info_includes_parent_context_string(self):
+        rodsadmin_headers = {'Authorization': f'Bearer {self.rodsadmin_bearer_token}'}
+        root_resource = 'issue_473_root_resc'
+        child_resource = 'issue_473_child_resc'
+
+        try:
+            # Create two resources.
+            r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                'op': 'create',
+                'name': root_resource,
+                'type': 'replication'
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                'op': 'create',
+                'name': child_resource,
+                'type': 'passthru'
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Make the passthru resource a child of the replication resource.
+            # No parent context string is set. This verifies that empty strings do
+            # not break the stat operation.
+            r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                'op': 'add_child',
+                'parent-name': root_resource,
+                'child-name': child_resource
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Show the parent context string is available, but empty.
+            r = requests.get(self.url_endpoint, headers=rodsadmin_headers, params={
+                'op': 'stat',
+                'name': child_resource
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['exists'], True)
+            self.assertEqual(result['info']['parent_context'], '')
+
+            # Remove the child resource from the parent resource.
+            r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                'op': 'remove_child',
+                'parent-name': root_resource,
+                'child-name': child_resource
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Make the passthru resource a child of the replication resource again,
+            # but set the parent context string too.
+            parent_context = 'issue_473_parent_context'
+            r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                'op': 'add_child',
+                'parent-name': root_resource,
+                'child-name': child_resource,
+                'context': parent_context
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            self.assertEqual(r.json()['irods_response']['status_code'], 0)
+
+            # Show the parent context string matches the string we expect.
+            r = requests.get(self.url_endpoint, headers=rodsadmin_headers, params={
+                'op': 'stat',
+                'name': child_resource
+            })
+            self.logger.debug(r.content)
+            self.assertEqual(r.status_code, 200)
+            result = r.json()
+            self.assertEqual(result['irods_response']['status_code'], 0)
+            self.assertEqual(result['exists'], True)
+            self.assertEqual(result['info']['parent_context'], parent_context)
+
+        finally:
+            # Remove the child resource from the parent resource.
+            r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                'op': 'remove_child',
+                'parent-name': root_resource,
+                'child-name': child_resource
+            })
+            self.logger.debug(r.content)
+
+            # Remove the resources.
+            for resc in [root_resource, child_resource]:
+                r = requests.post(self.url_endpoint, headers=rodsadmin_headers, data={
+                    'op': 'remove',
+                    'name': resc
+                })
+                self.logger.debug(r.content)
+
 class test_rules_endpoint(unittest.TestCase):
 
     @classmethod


### PR DESCRIPTION
Depends on irods/irods#9009.

Compiles against 4.3.2 and all tests pass except one (due to iRODS 5 access time). This is expected.

Compiles against irods/irods (tip of main) and all tests pass.
Tested with 4.2 compatibility option enabled too.